### PR TITLE
Add `exp` operator

### DIFF
--- a/src/ntops/__init__.py
+++ b/src/ntops/__init__.py
@@ -3,6 +3,7 @@ from ntops.add import add
 from ntops.addmm import addmm
 from ntops.bmm import bmm
 from ntops.div import div
+from ntops.exp import exp
 from ntops.mm import mm
 
-__all__ = ["abs", "add", "addmm", "bmm", "div", "mm"]
+__all__ = ["abs", "add", "addmm", "bmm", "div", "exp", "mm"]

--- a/src/ntops/exp.py
+++ b/src/ntops/exp.py
@@ -1,0 +1,30 @@
+import functools
+
+import ninetoothed
+import ninetoothed.language as ntl
+import torch
+from ninetoothed import Tensor
+
+from ntops import element_wise
+
+
+def application(input, output):
+    output = ntl.exp(input)  # noqa: F841
+
+
+def exp(input, output=None):
+    if output is None:
+        output = torch.empty_like(input)
+
+    kernel = _make(input.ndim)
+
+    kernel(input, output)
+
+    return output
+
+
+@functools.cache
+def _make(ndim):
+    return ninetoothed.make(
+        element_wise.arrangement, application, (Tensor(ndim), Tensor(ndim))
+    )

--- a/tests/test_exp.py
+++ b/tests/test_exp.py
@@ -1,0 +1,23 @@
+import pytest
+import torch
+
+import ntops
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    # TODO: Test for `float16` later.
+    if dtype is torch.float16:
+        return
+
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.exp(input)
+    reference_output = torch.exp(input)
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 38 items

tests/test_abs.py ........                                               [ 21%]
tests/test_add.py ........                                               [ 42%]
tests/test_addmm.py ..                                                   [ 47%]
tests/test_bmm.py ..                                                     [ 52%]
tests/test_div.py ........                                               [ 73%]
tests/test_exp.py ........                                               [ 94%]
tests/test_mm.py ..                                                      [100%]

======================== 38 passed in 299.54s (0:04:59) ========================
```
