### PR TITLE
Add `mul` operator

### DIFF
--- a/src/ntops/__init__.py
+++ b/src/ntops/__init__.py
@@ -6,5 +6,6 @@ from ntops.div import div
 from ntops.exp import exp
 from ntops.gelu import gelu
 from ntops.mm import mm
+from ntops.mul import mul
 
-__all__ = ["abs", "add", "addmm", "bmm", "div", "exp", "gelu", "mm"]
+__all__ = ["abs", "add", "addmm", "bmm", "div", "exp", "gelu", "mm", "mul"]

--- a/src/ntops/mul.py
+++ b/src/ntops/mul.py
@@ -1,0 +1,29 @@
+import functools
+
+import ninetoothed
+import torch
+from ninetoothed import Tensor
+
+from ntops import element_wise
+
+
+def application(input, other, output):
+    output = input * other  # noqa: F841
+
+
+def mul(input, other, output=None):
+    if output is None:
+        output = torch.empty_like(input)
+
+    kernel = _make(input.ndim)
+
+    kernel(input, other, output)
+
+    return output
+
+
+@functools.cache
+def _make(ndim):
+    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+
+    return ninetoothed.make(element_wise.arrangement, application, tensors)

--- a/tests/test_mul.py
+++ b/tests/test_mul.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+
+import ntops
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+    other = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.mul(input, other)
+    reference_output = torch.mul(input, other)
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 54 items

tests/test_abs.py ........                                               [ 14%]
tests/test_add.py ........                                               [ 29%]
tests/test_addmm.py ..                                                   [ 33%]
tests/test_bmm.py ..                                                     [ 37%]
tests/test_div.py ........                                               [ 51%]
tests/test_exp.py ........                                               [ 66%]
tests/test_gelu.py ........                                              [ 81%]
tests/test_mm.py ..                                                      [ 85%]
tests/test_mul.py ........                                               [100%]

======================== 54 passed in 73.08s (0:01:13) =========================
```
