### PR TITLE
Add `rsqrt` operator

### DIFF
--- a/src/ntops/__init__.py
+++ b/src/ntops/__init__.py
@@ -7,5 +7,6 @@ from ntops.exp import exp
 from ntops.gelu import gelu
 from ntops.mm import mm
 from ntops.mul import mul
+from ntops.rsqrt import rsqrt
 
-__all__ = ["abs", "add", "addmm", "bmm", "div", "exp", "gelu", "mm", "mul"]
+__all__ = ["abs", "add", "addmm", "bmm", "div", "exp", "gelu", "mm", "mul", "rsqrt"]

--- a/src/ntops/rsqrt.py
+++ b/src/ntops/rsqrt.py
@@ -1,0 +1,32 @@
+import functools
+
+import ninetoothed
+import ninetoothed.language as ntl
+import torch
+from ninetoothed import Tensor
+
+from ntops import element_wise
+
+
+def application(input, output):
+    output = ntl.rsqrt(ntl.cast(input, ntl.float32))  # noqa: F841
+
+
+def rsqrt(input, output=None):
+    if output is None:
+        output = torch.empty_like(input)
+
+    kernel = _make(input.ndim)
+
+    kernel(input, output)
+
+    return output
+
+
+@functools.cache
+def _make(ndim):
+    return ninetoothed.make(
+        element_wise.arrangement,
+        application,
+        (Tensor(ndim), Tensor(ndim)),
+    )

--- a/tests/test_rsqrt.py
+++ b/tests/test_rsqrt.py
@@ -1,0 +1,23 @@
+import random
+
+import pytest
+import torch
+
+import ntops
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.rsqrt(input)
+    reference_output = torch.rsqrt(input)
+
+    assert torch.allclose(
+        ninetoothed_output, reference_output, atol=atol, rtol=rtol, equal_nan=True
+    )

--- a/tests/test_rsqrt.py
+++ b/tests/test_rsqrt.py
@@ -1,5 +1,3 @@
-import random
-
 import pytest
 import torch
 


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 62 items

tests/test_abs.py ........                                               [ 12%]
tests/test_add.py ........                                               [ 25%]
tests/test_addmm.py ..                                                   [ 29%]
tests/test_bmm.py ..                                                     [ 32%]
tests/test_div.py ........                                               [ 45%]
tests/test_exp.py ........                                               [ 58%]
tests/test_gelu.py ........                                              [ 70%]
tests/test_mm.py ..                                                      [ 74%]
tests/test_mul.py ........                                               [ 87%]
tests/test_rsqrt.py ........                                             [100%]

======================== 62 passed in 95.87s (0:01:35) =========================
```
