### PR TITLE
Add `relu` operator

### DIFF
--- a/src/ntops/kernels/relu.py
+++ b/src/ntops/kernels/relu.py
@@ -1,0 +1,15 @@
+import functools
+
+import ninetoothed
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, output):
+    output = max(0.0, input)  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    return ninetoothed.make(arrangement, application,(Tensor(ndim), Tensor(ndim)))

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -9,6 +9,7 @@ import ntops.kernels.exp
 import ntops.kernels.gelu
 import ntops.kernels.mm
 import ntops.kernels.mul
+import ntops.kernels.relu
 import ntops.kernels.rsqrt
 
 
@@ -115,6 +116,17 @@ def mul(input, other, *, out=None):
     kernel = ntops.kernels.mul.make(input.ndim)
 
     kernel(input, other, out)
+
+    return out
+
+
+def relu(input, *, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+
+    kernel = ntops.kernels.relu.make(input.ndim)
+
+    kernel(input, out)
 
     return out
 

--- a/tests/test_relu.py
+++ b/tests/test_relu.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.torch.relu(input)
+    reference_output = F.relu(input)
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts =============================
platform linux -- Python 3.11.7, pytest-8.3.5, pluggy-1.5.0
rootdir: /root/projects/ntops
configfile: pyproject.toml
plugins: cov-6.1.1
collected 70 items

tests/test_abs.py ........                                                [ 11%]
tests/test_add.py ........                                                [ 22%]
tests/test_addmm.py ..                                                    [ 25%]
tests/test_bmm.py ..                                                      [ 28%]
tests/test_div.py ........                                                [ 40%]
tests/test_exp.py ........                                                [ 51%]
tests/test_gelu.py ........                                               [ 62%]
tests/test_mm.py ..                                                       [ 65%]
tests/test_mul.py ........                                                [ 77%]
tests/test_relu.py ........                                               [ 88%]
tests/test_rsqrt.py ........                                              [100%]

======================== 70 passed in 808.34s (0:13:28) ========================
```
