### PR TITLE
Add `relu` operator

### DIFF
--- a/src/ntops/kernels/relu.py
+++ b/src/ntops/kernels/relu.py
@@ -1,0 +1,15 @@
+import functools
+
+import ninetoothed
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, output):
+    output = max(0.0, input)  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    return ninetoothed.make(arrangement, application,(Tensor(ndim), Tensor(ndim)))

--- a/src/ntops/kernels/relu.py
+++ b/src/ntops/kernels/relu.py
@@ -6,22 +6,12 @@ from ninetoothed import Tensor
 from ntops.kernels.element_wise import arrangement
 
 
-def default_application(input, output):
+def application(input, output):
     output = max(0.0, input)  # noqa: F841
 
 
-def True_application(input, output):
-    input = max(0.0, input)  
-    output = input  # noqa: F841
-
-
 @functools.cache
-def make(ndim, replace):
-    if replace == True:
-        application = True_application
-    else:
-        application = default_application
-
+def make(ndim):
     tensors = (Tensor(ndim), Tensor(ndim))
 
     return ninetoothed.make(arrangement, application, tensors)

--- a/src/ntops/kernels/relu.py
+++ b/src/ntops/kernels/relu.py
@@ -6,10 +6,22 @@ from ninetoothed import Tensor
 from ntops.kernels.element_wise import arrangement
 
 
-def application(input, output):
+def default_application(input, output):
     output = max(0.0, input)  # noqa: F841
 
 
+def True_application(input, output):
+    input = max(0.0, input)  
+    output = input  # noqa: F841
+
+
 @functools.cache
-def make(ndim):
-    return ninetoothed.make(arrangement, application,(Tensor(ndim), Tensor(ndim)))
+def make(ndim, replace):
+    if replace == True:
+        application = True_application
+    else:
+        application = default_application
+
+    tensors = (Tensor(ndim), Tensor(ndim))
+
+    return ninetoothed.make(arrangement, application, tensors)

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -9,6 +9,7 @@ import ntops.kernels.exp
 import ntops.kernels.gelu
 import ntops.kernels.mm
 import ntops.kernels.mul
+import ntops.kernels.relu
 import ntops.kernels.rsqrt
 
 
@@ -115,6 +116,17 @@ def mul(input, other, *, out=None):
     kernel = ntops.kernels.mul.make(input.ndim)
 
     kernel(input, other, out)
+
+    return out
+
+
+def relu(input, *, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+
+    kernel = ntops.kernels.relu.make(input.ndim)
+
+    kernel(input, out)
 
     return out
 

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -120,15 +120,14 @@ def mul(input, other, *, out=None):
     return out
 
 
-def relu(input, out=None):
-    if out is None:
-        out = torch.empty_like(input)
+def relu(input, inplace=False):
+    output = torch.empty_like(input)
 
-    kernel = ntops.kernels.relu.make(input.ndim)
+    kernel = ntops.kernels.relu.make(input.ndim, inplace)
 
-    kernel(input, out)
+    kernel(input, output)
 
-    return out
+    return output
 
 
 def rsqrt(input, *, out=None):

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -121,9 +121,12 @@ def mul(input, other, *, out=None):
 
 
 def relu(input, inplace=False):
-    output = torch.empty_like(input)
+    if inplace:
+        output = input
+    else:
+        output = torch.empty_like(input)
 
-    kernel = ntops.kernels.relu.make(input.ndim, inplace)
+    kernel = ntops.kernels.relu.make(input.ndim)
 
     kernel(input, output)
 

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -120,7 +120,7 @@ def mul(input, other, *, out=None):
     return out
 
 
-def relu(input, *, out=None):
+def relu(input, out=None):
     if out is None:
         out = torch.empty_like(input)
 

--- a/tests/test_relu.py
+++ b/tests/test_relu.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.torch.relu(input)
+    reference_output = F.relu(input)
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)

--- a/tests/test_relu.py
+++ b/tests/test_relu.py
@@ -14,7 +14,10 @@ def test_cuda(shape, dtype, atol, rtol):
 
     input = torch.randn(shape, dtype=dtype, device=device)
 
-    ninetoothed_output = ntops.torch.relu(input)
-    reference_output = F.relu(input)
+    for replace in (False, True):
+        ninetoothed_output = ntops.torch.relu(input, replace)
+        reference_output = F.relu(input, replace)
 
-    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)
+        assert torch.allclose(
+            ninetoothed_output, reference_output, atol=atol, rtol=rtol
+        )

--- a/tests/test_relu.py
+++ b/tests/test_relu.py
@@ -14,9 +14,9 @@ def test_cuda(shape, dtype, atol, rtol):
 
     input = torch.randn(shape, dtype=dtype, device=device)
 
-    for replace in (False, True):
-        ninetoothed_output = ntops.torch.relu(input, replace)
-        reference_output = F.relu(input, replace)
+    for inplace in (False, True):
+        ninetoothed_output = ntops.torch.relu(input, inplace)
+        reference_output = F.relu(input, inplace)
 
         assert torch.allclose(
             ninetoothed_output, reference_output, atol=atol, rtol=rtol


### PR DESCRIPTION
`pytest` output:

```
=============================== test session starts ================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/lsj/projects/ntops
configfile: pyproject.toml
plugins: cov-6.1.1
collected 70 items

tests/test_abs.py ........                                                   [ 11%]
tests/test_add.py ........                                                   [ 22%]
tests/test_addmm.py ..                                                       [ 25%]
tests/test_bmm.py ..                                                         [ 28%]
tests/test_div.py ........                                                   [ 40%]
tests/test_exp.py ........                                                   [ 51%]
tests/test_gelu.py ........                                                  [ 62%]
tests/test_mm.py ..                                                          [ 65%]
tests/test_mul.py ........                                                   [ 77%]
tests/test_relu.py ........                                                  [ 88%]
tests/test_rsqrt.py ........                                                 [100%]
                                                                                    
========================== 70 passed in 80.04s (0:01:20) ===========================
```
