### PR TITLE
Add `sin` operator

### DIFF
--- a/src/ntops/kernels/sin.py
+++ b/src/ntops/kernels/sin.py
@@ -1,0 +1,16 @@
+import functools
+
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, output):
+    output = ntl.sin(input)  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -10,6 +10,7 @@ import ntops.kernels.gelu
 import ntops.kernels.mm
 import ntops.kernels.mul
 import ntops.kernels.rsqrt
+import ntops.kernels.sin
 
 
 def abs(input, *, out=None):
@@ -124,6 +125,17 @@ def rsqrt(input, *, out=None):
         out = torch.empty_like(input)
 
     kernel = ntops.kernels.rsqrt.make(input.ndim)
+
+    kernel(input, out)
+
+    return out
+
+
+def sin(input, *, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+
+    kernel = ntops.kernels.sin.make(input.ndim)
 
     kernel(input, out)
 

--- a/tests/test_sin.py
+++ b/tests/test_sin.py
@@ -1,0 +1,23 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    # TODO: Test for `float16` later.
+    if dtype is torch.float16:
+        return
+
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.torch.sin(input)
+    reference_output = torch.sin(input)
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
`pytest` output:

```
=============================== test session starts ================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/lsj/projects/ntops
configfile: pyproject.toml
plugins: cov-6.1.1
collected 70 items

tests/test_abs.py ........                                                   [ 11%]
tests/test_add.py ........                                                   [ 22%]
tests/test_addmm.py ..                                                       [ 25%]
tests/test_bmm.py ..                                                         [ 28%]
tests/test_div.py ........                                                   [ 40%]
tests/test_exp.py ........                                                   [ 51%]
tests/test_gelu.py ........                                                  [ 62%]
tests/test_mm.py ..                                                          [ 65%]
tests/test_mul.py ........                                                   [ 77%]
tests/test_rsqrt.py ........                                                 [ 88%]
tests/test_sin.py ........                                                   [100%]

========================== 70 passed in 79.67s (0:01:19) ===========================
```

