### PR TITLE
Add `cos` operator

### DIFF
--- a/src/ntops/kernels/cos.py
+++ b/src/ntops/kernels/cos.py
@@ -1,0 +1,16 @@
+import functools
+
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, output):
+    output = ntl.cos(input)  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -4,6 +4,7 @@ import ntops.kernels.abs
 import ntops.kernels.add
 import ntops.kernels.addmm
 import ntops.kernels.bmm
+import ntops.kernels.cos
 import ntops.kernels.div
 import ntops.kernels.exp
 import ntops.kernels.gelu
@@ -58,6 +59,17 @@ def bmm(input, mat2, *, out=None):
     kernel = ntops.kernels.bmm.make()
 
     kernel(input, mat2, out)
+
+    return out
+
+
+def cos(input, *, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+
+    kernel = ntops.kernels.cos.make(input.ndim)
+
+    kernel(input, out)
 
     return out
 

--- a/tests/test_cos.py
+++ b/tests/test_cos.py
@@ -1,0 +1,23 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    # TODO: Test for `float16` later.
+    if dtype is torch.float16:
+        return
+
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.torch.cos(input)
+    reference_output = torch.cos(input)
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
`pytest` output:

```
=============================== test session starts ================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/lsj/projects/ntops
configfile: pyproject.toml
plugins: cov-6.1.1
collected 70 items

tests/test_abs.py ........                                                   [ 11%]
tests/test_add.py ........                                                   [ 22%]
tests/test_addmm.py ..                                                       [ 25%]
tests/test_bmm.py ..                                                         [ 28%]
tests/test_cos.py ........                                                   [ 40%]
tests/test_div.py ........                                                   [ 51%]
tests/test_exp.py ........                                                   [ 62%]
tests/test_gelu.py ........                                                  [ 74%]
tests/test_mm.py ..                                                          [ 77%]
tests/test_mul.py ........                                                   [ 88%]
tests/test_rsqrt.py ........                                                 [100%]

========================== 70 passed in 290.36s (0:04:50) ==========================
```
