### PR TITLE
Add `tanh` operator

### DIFF
--- a/src/ntops/kernels/tanh.py
+++ b/src/ntops/kernels/tanh.py
@@ -1,0 +1,18 @@
+import functools
+
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, output):
+    exp_input = ntl.exp(input)
+    exp_neg_input = ntl.exp(-input)
+    output = (exp_input - exp_neg_input) / (exp_input + exp_neg_input)  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -14,6 +14,7 @@ import ntops.kernels.relu
 import ntops.kernels.rsqrt
 import ntops.kernels.sigmoid
 import ntops.kernels.sin
+import ntops.kernels.tanh
 
 
 def abs(input, *, out=None):
@@ -174,6 +175,17 @@ def sin(input, *, out=None):
         out = torch.empty_like(input)
 
     kernel = ntops.kernels.sin.make(input.ndim)
+
+    kernel(input, out)
+
+    return out
+
+
+def tanh(input, *, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+
+    kernel = ntops.kernels.tanh.make(input.ndim)
 
     kernel(input, out)
 

--- a/tests/test_tanh.py
+++ b/tests/test_tanh.py
@@ -1,0 +1,23 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    # TODO: Test for `float16` later.
+    if dtype is torch.float16:
+        return
+
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.torch.tanh(input)
+    reference_output = torch.tanh(input)
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
`pytest` output:

```
=============================== test session starts ================================
platform linux -- Python 3.12.5, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/lsj/projects/ntops
configfile: pyproject.toml
plugins: cov-6.1.1
collected 102 items

tests/test_abs.py ........                                                   [  7%]
tests/test_add.py ........                                                   [ 15%]
tests/test_addmm.py ..                                                       [ 17%]
tests/test_bmm.py ..                                                         [ 19%]
tests/test_cos.py ........                                                   [ 27%]
tests/test_div.py ........                                                   [ 35%]
tests/test_exp.py ........                                                   [ 43%]
tests/test_gelu.py ........                                                  [ 50%]
tests/test_mm.py ..                                                          [ 52%]
tests/test_mul.py ........                                                   [ 60%]
tests/test_relu.py ........                                                  [ 68%]
tests/test_rsqrt.py ........                                                 [ 76%]
tests/test_sigmoid.py ........                                               [ 84%]
tests/test_sin.py ........                                                   [ 92%]
tests/test_tanh.py ........                                                  [100%]

========================== 102 passed in 96.82s (0:01:36) ==========================
```
