### PR TITLE
Add `isinf` operator

### DIFF
--- a/src/ntops/kernels/isinf.py
+++ b/src/ntops/kernels/isinf.py
@@ -1,0 +1,17 @@
+import functools
+
+import ninetoothed
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, output):
+    pos_result = input == float("+inf")
+    neg_result = input == float("-inf")
+    output = pos_result or neg_result  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -8,6 +8,7 @@ import ntops.kernels.cos
 import ntops.kernels.div
 import ntops.kernels.exp
 import ntops.kernels.gelu
+import ntops.kernels.isinf
 import ntops.kernels.mm
 import ntops.kernels.mul
 import ntops.kernels.relu
@@ -103,6 +104,16 @@ def gelu(input, approximate="none"):
     output = torch.empty_like(input)
 
     kernel = ntops.kernels.gelu.make(input.ndim, approximate)
+
+    kernel(input, output)
+
+    return output
+
+
+def isinf(input):
+    output = torch.empty_like(input)
+
+    kernel = ntops.kernels.isinf.make(input.ndim)
 
     kernel(input, output)
 

--- a/tests/test_isinf.py
+++ b/tests/test_isinf.py
@@ -1,0 +1,27 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    def generate_inf_tensor(shape, dtype, device):
+        x = torch.randn(shape, dtype=dtype, device=device)
+        inf_prob = 0.5
+        mask = torch.rand(shape) < inf_prob
+        x[mask] = float("inf")
+        x[~mask] = float("-inf")
+        return x
+
+    input = generate_inf_tensor(shape, dtype, device)
+
+    ninetoothed_output = ntops.torch.isinf(input)
+    reference_output = torch.isinf(input)
+
+    assert torch.equal(ninetoothed_output, reference_output)


### PR DESCRIPTION
`pytest` output:

```
=============================== test session starts ================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0                         
rootdir: /home/lsj/projects/ntops                                                   
configfile: pyproject.toml                                                          
plugins: cov-6.1.1                                                                  
collected 102 items              

tests/test_abs.py ........                                                   [  7%] 
tests/test_add.py ........                                                   [ 15%] 
tests/test_addmm.py ..                                                       [ 17%] 
tests/test_bmm.py ..                                                         [ 19%] 
tests/test_cos.py ........                                                   [ 27%] 
tests/test_div.py ........                                                   [ 35%] 
tests/test_exp.py ........                                                   [ 43%] 
tests/test_gelu.py ........                                                  [ 50%] 
tests/test_isinf.py ........                                                 [ 58%] 
tests/test_mm.py ..                                                          [ 60%] 
tests/test_mul.py .....F..                                                   [ 68%] 
tests/test_relu.py .....F..                                                  [ 76%] 
tests/test_rsqrt.py ........                                                 [ 84%] 
tests/test_sigmoid.py ........                                               [ 92%] 
tests/test_sin.py ........                                                   [100%] 

```
