### PR TITLE
Add `ne` operator

### DIFF
--- a/src/ntops/kernels/ne.py
+++ b/src/ntops/kernels/ne.py
@@ -1,0 +1,17 @@
+import functools
+
+import ninetoothed
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, other, output):
+    output = input != other  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+
+    return ninetoothed.make(arrangement, application, tensors)

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -10,6 +10,7 @@ import ntops.kernels.exp
 import ntops.kernels.gelu
 import ntops.kernels.mm
 import ntops.kernels.mul
+import ntops.kernels.ne
 import ntops.kernels.relu
 import ntops.kernels.rsqrt
 import ntops.kernels.sigmoid
@@ -128,6 +129,17 @@ def mul(input, other, *, out=None):
         out = torch.empty_like(input)
 
     kernel = ntops.kernels.mul.make(input.ndim)
+
+    kernel(input, other, out)
+
+    return out
+
+
+def ne(input, other, *, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+
+    kernel = ntops.kernels.ne.make(input.ndim)
 
     kernel(input, other, out)
 

--- a/tests/test_ne.py
+++ b/tests/test_ne.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+    other = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.torch.ne(input, other)
+    reference_output = torch.ne(input, other)
+
+    assert torch.equal(ninetoothed_output, reference_output)


### PR DESCRIPTION
`pytest` output:

```
=============================== test session starts ================================
platform linux -- Python 3.12.5, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/lsj/projects/ntops
configfile: pyproject.toml
plugins: cov-6.1.1
collected 102 items

tests/test_abs.py ........                                                   [  7%]
tests/test_add.py ........                                                   [ 15%]
tests/test_addmm.py ..                                                       [ 17%]
tests/test_bmm.py ..                                                         [ 19%]
tests/test_cos.py ........                                                   [ 27%]
tests/test_div.py ........                                                   [ 35%]
tests/test_exp.py ........                                                   [ 43%]
tests/test_gelu.py ........                                                  [ 50%]
tests/test_mm.py ..                                                          [ 52%]
tests/test_mul.py ........                                                   [ 60%]
tests/test_ne.py ........                                                    [ 68%]
tests/test_relu.py ........                                                  [ 76%]
tests/test_rsqrt.py ........                                                 [ 84%]
tests/test_sigmoid.py ........                                               [ 92%]
tests/test_sin.py ........                                                   [100%]

========================= 102 passed in 102.59s (0:01:42) ==========================
```
