### PR TITLE
Add `isnan` operator

### DIFF
--- a/src/ntops/kernels/isnan.py
+++ b/src/ntops/kernels/isnan.py
@@ -1,0 +1,15 @@
+import functools
+
+import ninetoothed
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, output):
+    output = input != input  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -8,6 +8,7 @@ import ntops.kernels.cos
 import ntops.kernels.div
 import ntops.kernels.exp
 import ntops.kernels.gelu
+import ntops.kernels.isnan
 import ntops.kernels.mm
 import ntops.kernels.mul
 import ntops.kernels.relu
@@ -103,6 +104,16 @@ def gelu(input, approximate="none"):
     output = torch.empty_like(input)
 
     kernel = ntops.kernels.gelu.make(input.ndim, approximate)
+
+    kernel(input, output)
+
+    return output
+
+
+def isnan(input):
+    output = torch.empty_like(input)
+
+    kernel = ntops.kernels.isnan.make(input.ndim)
 
     kernel(input, output)
 

--- a/tests/test_isnan.py
+++ b/tests/test_isnan.py
@@ -1,0 +1,29 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    def generate_nan_tensor(shape, dtype, device):
+        nan_prob = 0.4
+        prob_tensor = torch.rand(shape, device=device)
+        mask = prob_tensor < nan_prob
+
+        x = torch.randn(shape, dtype=dtype, device=device)
+        x[mask] = float("nan")
+
+        return x
+
+    input = generate_nan_tensor(shape, dtype, device)
+
+    ninetoothed_output = ntops.torch.isnan(input)
+    reference_output = torch.isnan(input)
+
+    assert torch.equal(ninetoothed_output, reference_output)


### PR DESCRIPTION
`pytest` output:

```
=============================== test session starts ================================
platform linux -- Python 3.12.5, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/lsj/projects/ntops
configfile: pyproject.toml
plugins: cov-6.1.1
collected 102 items

tests/test_abs.py ........                                                   [  7%]
tests/test_add.py ........                                                   [ 15%]
tests/test_addmm.py ..                                                       [ 17%]
tests/test_bmm.py ..                                                         [ 19%]
tests/test_cos.py ........                                                   [ 27%]
tests/test_div.py ........                                                   [ 35%]
tests/test_exp.py ........                                                   [ 43%]
tests/test_gelu.py ........                                                  [ 50%]
tests/test_isnan.py ........                                                 [ 58%]
tests/test_mm.py ..                                                          [ 60%]
tests/test_mul.py ........                                                   [ 68%]
tests/test_relu.py ........                                                  [ 76%]
tests/test_rsqrt.py ........                                                 [ 84%]
tests/test_sigmoid.py ........                                               [ 92%]
tests/test_sin.py ........                                                   [100%]

========================= 102 passed in 103.17s (0:01:43) ==========================
```
