### PR TITLE
Add `lt` operator

### DIFF
--- a/src/ntops/kernels/lt.py
+++ b/src/ntops/kernels/lt.py
@@ -1,0 +1,17 @@
+import functools
+
+import ninetoothed
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, other, output):
+    output = input < other  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+
+    return ninetoothed.make(arrangement, application, tensors)

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -8,6 +8,7 @@ import ntops.kernels.cos
 import ntops.kernels.div
 import ntops.kernels.exp
 import ntops.kernels.gelu
+import ntops.kernels.lt
 import ntops.kernels.mm
 import ntops.kernels.mul
 import ntops.kernels.relu
@@ -119,6 +120,17 @@ def mm(input, mat2, *, out=None):
     kernel = ntops.kernels.mm.make()
 
     kernel(input, mat2, out)
+
+    return out
+
+
+def lt(input, other, *, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+
+    kernel = ntops.kernels.lt.make(input.ndim)
+
+    kernel(input, other, out)
 
     return out
 

--- a/tests/test_lt.py
+++ b/tests/test_lt.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+    other = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.torch.lt(input, other)
+    reference_output = torch.lt(input, other)
+
+    assert torch.equal(ninetoothed_output, reference_output)


### PR DESCRIPTION
`pytest` output:

```
=============================== test session starts ================================
platform linux -- Python 3.12.5, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/lsj/projects/ntops
configfile: pyproject.toml
plugins: cov-6.1.1
collected 102 items

tests/test_abs.py ........                                                   [  7%]
tests/test_add.py ........                                                   [ 15%]
tests/test_addmm.py ..                                                       [ 17%]
tests/test_bmm.py ..                                                         [ 19%]
tests/test_cos.py ........                                                   [ 27%]
tests/test_div.py ........                                                   [ 35%]
tests/test_exp.py ........                                                   [ 43%]
tests/test_gelu.py ........                                                  [ 50%]
tests/test_lt.py ........                                                    [ 58%]
tests/test_mm.py ..                                                          [ 60%]
tests/test_mul.py ........                                                   [ 68%]
tests/test_relu.py ........                                                  [ 76%]
tests/test_rsqrt.py ........                                                 [ 84%]
tests/test_sigmoid.py ........                                               [ 92%]
tests/test_sin.py ........                                                   [100%]
                                                                                    
========================= 102 passed in 101.98s (0:01:41) ==========================
```
