### PR TITLE
Add `bitwise_or` operator

### DIFF
--- a/src/ntops/kernels/bitwise_or.py
+++ b/src/ntops/kernels/bitwise_or.py
@@ -1,0 +1,25 @@
+import functools
+
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, other, output):
+    output = ntl.inline_asm_elementwise(  # noqa: F841
+        "or.b32 $0, $1, $2;",
+        "=r,r,r",
+        args=[input, other],
+        dtype=input.dtype,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@functools.cache
+def make(ndim):
+    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+
+    return ninetoothed.make(arrangement, application, tensors)

--- a/src/ntops/kernels/bitwise_or.py
+++ b/src/ntops/kernels/bitwise_or.py
@@ -1,21 +1,13 @@
 import functools
 
 import ninetoothed
-import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
 
 
 def application(input, other, output):
-    output = ntl.inline_asm_elementwise(  # noqa: F841
-        "or.b32 $0, $1, $2;",
-        "=r,r,r",
-        args=[input, other],
-        dtype=input.dtype,
-        is_pure=True,
-        pack=1,
-    )
+    output = input | other  # noqa: F841
 
 
 @functools.cache

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -3,6 +3,7 @@ import torch
 import ntops.kernels.abs
 import ntops.kernels.add
 import ntops.kernels.addmm
+import ntops.kernels.bitwise_or
 import ntops.kernels.bmm
 import ntops.kernels.cos
 import ntops.kernels.div
@@ -48,6 +49,17 @@ def addmm(input, mat1, mat2, *, beta=1, alpha=1, out=None):
     kernel = ntops.kernels.addmm.make()
 
     kernel(input, mat1, mat2, beta, alpha, out)
+
+    return out
+
+
+def bitwise_or(input, other, *, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+
+    kernel = ntops.kernels.bitwise_or.make(input.ndim)
+
+    kernel(input, other, out)
 
     return out
 

--- a/tests/test_bitwise_or.py
+++ b/tests/test_bitwise_or.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments(False))
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    if dtype == torch.bool:
+        prob = 0.5
+        input = torch.rand(shape, dtype=torch.float32, device=device) > prob
+        other = torch.rand(shape, dtype=torch.float32, device=device) > prob
+    else:
+        upper_bound = 10
+        input = torch.randint(
+            -upper_bound, upper_bound, size=shape, dtype=dtype, device=device
+        )
+        other = torch.randint(
+            -upper_bound, upper_bound, size=shape, dtype=dtype, device=device
+        )
+
+    ninetoothed_output = ntops.torch.bitwise_or(input, other)
+    reference_output = torch.bitwise_or(input, other)
+
+    assert torch.equal(ninetoothed_output, reference_output)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,11 +4,15 @@ import random
 import torch
 
 
-def generate_arguments():
+def generate_arguments(use_float=True):
     arguments = []
+    if use_float:
+        dtype_arr = (torch.float32, torch.float16)
+    else:
+        dtype_arr = (torch.bool, torch.int8, torch.int16, torch.int32)
 
     for ndim in range(1, 5):
-        for dtype in (torch.float32, torch.float16):
+        for dtype in dtype_arr:
             if dtype is torch.float32:
                 atol = 0.001
                 rtol = 0.001


### PR DESCRIPTION
`pytest` output:

```
=============================== test session starts ================================
platform linux -- Python 3.12.5, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/lsj/projects/ntops
configfile: pyproject.toml
plugins: cov-6.1.1
collected 110 items

tests/test_abs.py ........                                                   [  7%]
tests/test_add.py ........                                                   [ 14%]
tests/test_addmm.py ..                                                       [ 16%]
tests/test_bitwise_or.py ................                                    [ 30%]
tests/test_bmm.py ..                                                         [ 32%]
tests/test_cos.py ........                                                   [ 40%]
tests/test_div.py ........                                                   [ 47%]
tests/test_exp.py ........                                                   [ 54%]
tests/test_gelu.py ........                                                  [ 61%]
tests/test_mm.py ..                                                          [ 63%]
tests/test_mul.py ........                                                   [ 70%]
tests/test_relu.py ........                                                  [ 78%]
tests/test_rsqrt.py ........                                                 [ 85%]
tests/test_sigmoid.py ........                                               [ 92%]
tests/test_sin.py ........                                                   [100%]

========================= 110 passed in 116.96s (0:01:56) ==========================
```
