### PR TITLE
Expose `torch` via `__all__`

### DIFF
--- a/src/ntops/__init__.py
+++ b/src/ntops/__init__.py
@@ -1,0 +1,3 @@
+import torch
+
+__all__ = ["torch"]


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 94 items

tests/test_abs.py ........                                               [  8%]
tests/test_add.py ........                                               [ 17%]
tests/test_addmm.py ..                                                   [ 19%]
tests/test_bmm.py ..                                                     [ 21%]
tests/test_cos.py ........                                               [ 29%]
tests/test_div.py ........                                               [ 38%]
tests/test_exp.py ........                                               [ 46%]
tests/test_gelu.py ........                                              [ 55%]
tests/test_mm.py ..                                                      [ 57%]
tests/test_mul.py ........                                               [ 65%]
tests/test_relu.py ........                                              [ 74%]
tests/test_rsqrt.py ........                                             [ 82%]
tests/test_sigmoid.py ........                                           [ 91%]
tests/test_sin.py ........                                               [100%]

======================== 94 passed in 112.96s (0:01:52) ========================
```
