### PR TITLE
Make the `element_wise.arrangement` function accept customizable `block_size` parameter

### DIFF
--- a/src/ntops/kernels/element_wise.py
+++ b/src/ntops/kernels/element_wise.py
@@ -1,12 +1,12 @@
 import ninetoothed
 
 
-def arrangement(*tensors):
+def arrangement(*tensors, block_size=ninetoothed.block_size()):
     ndim = max(tensor.ndim for tensor in tensors)
 
     assert all(tensor.ndim == ndim or tensor.ndim == 0 for tensor in tensors)
 
-    block_shape = tuple(1 for _ in range(ndim - 1)) + (ninetoothed.block_size(),)
+    block_shape = tuple(1 for _ in range(ndim - 1)) + (block_size,)
 
     return tuple(
         tensor.tile(block_shape) if tensor.ndim != 0 else tensor for tensor in tensors


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 158 items

tests/test_abs.py ........                                               [  5%]
tests/test_add.py ........                                               [ 10%]
tests/test_addmm.py ..                                                   [ 11%]
tests/test_bmm.py ..                                                     [ 12%]
tests/test_cos.py ........                                               [ 17%]
tests/test_div.py ........                                               [ 22%]
tests/test_eq.py ........                                                [ 27%]
tests/test_exp.py ........                                               [ 32%]
tests/test_ge.py ........                                                [ 37%]
tests/test_gelu.py ........                                              [ 43%]
tests/test_gt.py ........                                                [ 48%]
tests/test_isinf.py ........                                             [ 53%]
tests/test_isnan.py ........                                             [ 58%]
tests/test_le.py ........                                                [ 63%]
tests/test_mm.py ..                                                      [ 64%]
tests/test_mul.py ........                                               [ 69%]
tests/test_ne.py ........                                                [ 74%]
tests/test_relu.py ........                                              [ 79%]
tests/test_rsqrt.py ........                                             [ 84%]
tests/test_sigmoid.py ........                                           [ 89%]
tests/test_sin.py ........                                               [ 94%]
tests/test_tanh.py ........                                              [100%]

======================= 158 passed in 845.69s (0:14:05) ========================
```
