### PR TITLE
Add `dropout` operator

### DIFF
--- a/src/ntops/kernels/dropout.py
+++ b/src/ntops/kernels/dropout.py
@@ -1,0 +1,18 @@
+import functools
+
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, p, seed, output):
+    output = ntl.where(ntl.rand(seed, input.offsets()) > p, input / (1 - p), 0)  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    tensors = (Tensor(ndim), Tensor(0), Tensor(0), Tensor(ndim))
+
+    return ninetoothed.make(arrangement, application, tensors)

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -1,3 +1,5 @@
+import random
+
 import torch
 
 import ntops.kernels.abs
@@ -10,6 +12,7 @@ import ntops.kernels.bmm
 import ntops.kernels.clamp
 import ntops.kernels.cos
 import ntops.kernels.div
+import ntops.kernels.dropout
 import ntops.kernels.eq
 import ntops.kernels.exp
 import ntops.kernels.ge
@@ -145,6 +148,27 @@ def div(input, other, *, rounding_mode=None, out=None):
     kernel(input, other, out)
 
     return out
+
+
+def dropout(input, p=0.5, training=True, inplace=False):
+    if not training or p == 0:
+        if inplace:
+            return input
+        else:
+            return input.clone()
+
+    seed = random.randrange(0, 2**31)
+
+    if inplace:
+        output = input
+    else:
+        output = torch.empty_like(input)
+
+    kernel = ntops.kernels.dropout.make(input.ndim)
+
+    kernel(input, p, seed, output)
+
+    return output
 
 
 def exp(input, *, out=None):

--- a/tests/test_dropout.py
+++ b/tests/test_dropout.py
@@ -1,0 +1,40 @@
+import random
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+    p = random.uniform(0, 1)
+
+    # TODO: Add `training` and `inplace` tests later.
+    ninetoothed_output = ntops.torch.dropout(input, p=p)
+    reference_output = F.dropout(input, p=p)
+
+    assert ninetoothed_output.shape == reference_output.shape
+
+    ninetoothed_non_zero_ratio = (
+        ninetoothed_output.nonzero().numel() / ninetoothed_output.ndim / input.numel()
+    )
+    reference_non_zero_ratio = (
+        reference_output.nonzero().numel() / reference_output.ndim / input.numel()
+    )
+
+    print(abs(ninetoothed_non_zero_ratio - reference_non_zero_ratio))
+
+    assert abs(ninetoothed_non_zero_ratio - reference_non_zero_ratio) < 0.1
+
+    assert torch.allclose(
+        ninetoothed_output[ninetoothed_output != 0],
+        input[ninetoothed_output != 0] / (1 - p),
+    )


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 246 items

tests/test_abs.py ........                                               [  3%]
tests/test_add.py ........                                               [  6%]
tests/test_addmm.py ..                                                   [  7%]
tests/test_bitwise_and.py ................                               [ 13%]
tests/test_bitwise_not.py ................                               [ 20%]
tests/test_bitwise_or.py ................                                [ 26%]
tests/test_bmm.py ..                                                     [ 27%]
tests/test_clamp.py ........                                             [ 30%]
tests/test_cos.py ........                                               [ 34%]
tests/test_div.py ........                                               [ 37%]
tests/test_dropout.py ........                                           [ 40%]
tests/test_eq.py ........                                                [ 43%]
tests/test_exp.py ........                                               [ 47%]
tests/test_ge.py ........                                                [ 50%]
tests/test_gelu.py ........                                              [ 53%]
tests/test_gt.py ........                                                [ 56%]
tests/test_isinf.py ........                                             [ 60%]
tests/test_isnan.py ........                                             [ 63%]
tests/test_le.py ........                                                [ 66%]
tests/test_lt.py ........                                                [ 69%]
tests/test_mm.py ..                                                      [ 70%]
tests/test_mul.py ........                                               [ 73%]
tests/test_ne.py ........                                                [ 77%]
tests/test_neg.py ........                                               [ 80%]
tests/test_relu.py ........                                              [ 83%]
tests/test_rsqrt.py ........                                             [ 86%]
tests/test_sigmoid.py ........                                           [ 90%]
tests/test_sin.py ........                                               [ 93%]
tests/test_softmax.py ........                                           [ 96%]
tests/test_tanh.py ........                                              [100%]

======================= 246 passed in 469.74s (0:07:49) ========================
```
