### PR TITLE
Add `pow` operator

### DIFF
--- a/src/ntops/kernels/pow.py
+++ b/src/ntops/kernels/pow.py
@@ -1,0 +1,18 @@
+import functools
+
+import ninetoothed
+from ninetoothed import Tensor
+from ninetoothed.language import libdevice
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, exponent, output):
+    output = libdevice.pow(input, exponent)  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+
+    return ninetoothed.make(arrangement, application, tensors)

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -26,6 +26,7 @@ import ntops.kernels.mm
 import ntops.kernels.mul
 import ntops.kernels.ne
 import ntops.kernels.neg
+import ntops.kernels.pow
 import ntops.kernels.relu
 import ntops.kernels.rsqrt
 import ntops.kernels.sigmoid
@@ -310,6 +311,17 @@ def neg(input, *, out=None):
     kernel = ntops.kernels.neg.make(input.ndim)
 
     kernel(input, out)
+
+    return out
+
+
+def pow(input, exponent, *, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+
+    kernel = ntops.kernels.pow.make(input.ndim)
+
+    kernel(input, exponent, out)
 
     return out
 

--- a/tests/test_pow.py
+++ b/tests/test_pow.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    # TODO: Test for `float16` later.
+    if dtype is torch.float16:
+        return
+
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+    exponent = torch.randn(shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.torch.pow(input, exponent)
+    reference_output = torch.pow(input, exponent)
+
+    assert torch.allclose(
+        ninetoothed_output, reference_output, atol=atol, rtol=rtol, equal_nan=True
+    )


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 254 items

tests/test_abs.py ........                                               [  3%]
tests/test_add.py ........                                               [  6%]
tests/test_addmm.py ..                                                   [  7%]
tests/test_bitwise_and.py ................                               [ 13%]
tests/test_bitwise_not.py ................                               [ 19%]
tests/test_bitwise_or.py ................                                [ 25%]
tests/test_bmm.py ..                                                     [ 26%]
tests/test_clamp.py ........                                             [ 29%]
tests/test_cos.py ........                                               [ 33%]
tests/test_div.py ........                                               [ 36%]
tests/test_dropout.py ........                                           [ 39%]
tests/test_eq.py ........                                                [ 42%]
tests/test_exp.py ........                                               [ 45%]
tests/test_ge.py ........                                                [ 48%]
tests/test_gelu.py ........                                              [ 51%]
tests/test_gt.py ........                                                [ 55%]
tests/test_isinf.py ........                                             [ 58%]
tests/test_isnan.py ........                                             [ 61%]
tests/test_le.py ........                                                [ 64%]
tests/test_lt.py ........                                                [ 67%]
tests/test_mm.py ..                                                      [ 68%]
tests/test_mul.py ........                                               [ 71%]
tests/test_ne.py ........                                                [ 74%]
tests/test_neg.py ........                                               [ 77%]
tests/test_pow.py ........                                               [ 81%]
tests/test_relu.py ........                                              [ 84%]
tests/test_rsqrt.py ........                                             [ 87%]
tests/test_sigmoid.py ........                                           [ 90%]
tests/test_sin.py ........                                               [ 93%]
tests/test_softmax.py ........                                           [ 96%]
tests/test_tanh.py ........                                              [100%]

======================= 254 passed in 239.92s (0:03:59) ========================
```
