### PR TITLE
Add `sub` operator

### DIFF
--- a/src/ntops/kernels/sub.py
+++ b/src/ntops/kernels/sub.py
@@ -1,0 +1,17 @@
+import functools
+
+import ninetoothed
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, other, alpha, output):
+    output = input - alpha * other  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    tensors = (Tensor(ndim), Tensor(ndim), Tensor(0), Tensor(ndim))
+
+    return ninetoothed.make(arrangement, application, tensors)

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -32,6 +32,7 @@ import ntops.kernels.rsqrt
 import ntops.kernels.sigmoid
 import ntops.kernels.sin
 import ntops.kernels.softmax
+import ntops.kernels.sub
 import ntops.kernels.tanh
 
 
@@ -382,6 +383,17 @@ def softmax(input, dim, dtype=None):
     kernel(input, output)
 
     return output
+
+
+def sub(input, other, *, alpha=1, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+
+    kernel = ntops.kernels.sub.make(input.ndim)
+
+    kernel(input, other, alpha, out)
+
+    return out
 
 
 def tanh(input, *, out=None):

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -1,0 +1,21 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import gauss, generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+    other = torch.randn(shape, dtype=dtype, device=device)
+    alpha = gauss()
+
+    ninetoothed_output = ntops.torch.sub(input, other, alpha=alpha)
+    reference_output = torch.sub(input, other, alpha=alpha)
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 262 items

tests/test_abs.py ........                                               [  3%]
tests/test_add.py ........                                               [  6%]
tests/test_addmm.py ..                                                   [  6%]
tests/test_bitwise_and.py ................                               [ 12%]
tests/test_bitwise_not.py ................                               [ 19%]
tests/test_bitwise_or.py ................                                [ 25%]
tests/test_bmm.py ..                                                     [ 25%]
tests/test_clamp.py ........                                             [ 29%]
tests/test_cos.py ........                                               [ 32%]
tests/test_div.py ........                                               [ 35%]
tests/test_dropout.py ........                                           [ 38%]
tests/test_eq.py ........                                                [ 41%]
tests/test_exp.py ........                                               [ 44%]
tests/test_ge.py ........                                                [ 47%]
tests/test_gelu.py ........                                              [ 50%]
tests/test_gt.py ........                                                [ 53%]
tests/test_isinf.py ........                                             [ 56%]
tests/test_isnan.py ........                                             [ 59%]
tests/test_le.py ........                                                [ 62%]
tests/test_lt.py ........                                                [ 65%]
tests/test_mm.py ..                                                      [ 66%]
tests/test_mul.py ........                                               [ 69%]
tests/test_ne.py ........                                                [ 72%]
tests/test_neg.py ........                                               [ 75%]
tests/test_pow.py ........                                               [ 78%]
tests/test_relu.py ........                                              [ 81%]
tests/test_rsqrt.py ........                                             [ 84%]
tests/test_sigmoid.py ........                                           [ 87%]
tests/test_sin.py ........                                               [ 90%]
tests/test_softmax.py ........                                           [ 93%]
tests/test_sub.py ........                                               [ 96%]
tests/test_tanh.py ........                                              [100%]

======================= 262 passed in 285.13s (0:04:45) ========================
```
