### PR TITLE
Add `silu` operator

### DIFF
--- a/src/ntops/kernels/silu.py
+++ b/src/ntops/kernels/silu.py
@@ -1,0 +1,18 @@
+import functools
+
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Tensor
+
+from ntops.kernels.element_wise import arrangement
+
+
+def application(input, output):
+    output = input / (1 + ntl.exp(-ntl.cast(input, ntl.float32)))  # noqa: F841
+
+
+@functools.cache
+def make(ndim):
+    tensors = (Tensor(ndim), Tensor(ndim))
+
+    return ninetoothed.make(arrangement, application, tensors)

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -30,6 +30,7 @@ import ntops.kernels.pow
 import ntops.kernels.relu
 import ntops.kernels.rsqrt
 import ntops.kernels.sigmoid
+import ntops.kernels.silu
 import ntops.kernels.sin
 import ntops.kernels.softmax
 import ntops.kernels.sub
@@ -360,6 +361,19 @@ def sigmoid(input, *, out=None):
     kernel(input, out)
 
     return out
+
+
+def silu(input, inplace=False):
+    if inplace:
+        output = input
+    else:
+        output = torch.empty_like(input)
+
+    kernel = ntops.kernels.silu.make(input.ndim)
+
+    kernel(input, output)
+
+    return output
 
 
 def sin(input, *, out=None):

--- a/tests/test_silu.py
+++ b/tests/test_silu.py
@@ -1,0 +1,21 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol):
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+
+    # TODO: Add `inplace` tests later.
+    ninetoothed_output = ntops.torch.silu(input)
+    reference_output = F.silu(input)
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 270 items

tests/test_abs.py ........                                               [  2%]
tests/test_add.py ........                                               [  5%]
tests/test_addmm.py ..                                                   [  6%]
tests/test_bitwise_and.py ................                               [ 12%]
tests/test_bitwise_not.py ................                               [ 18%]
tests/test_bitwise_or.py ................                                [ 24%]
tests/test_bmm.py ..                                                     [ 25%]
tests/test_clamp.py ........                                             [ 28%]
tests/test_cos.py ........                                               [ 31%]
tests/test_div.py ........                                               [ 34%]
tests/test_dropout.py ........                                           [ 37%]
tests/test_eq.py ........                                                [ 40%]
tests/test_exp.py ........                                               [ 42%]
tests/test_ge.py ........                                                [ 45%]
tests/test_gelu.py ........                                              [ 48%]
tests/test_gt.py ........                                                [ 51%]
tests/test_isinf.py ........                                             [ 54%]
tests/test_isnan.py ........                                             [ 57%]
tests/test_le.py ........                                                [ 60%]
tests/test_lt.py ........                                                [ 63%]
tests/test_mm.py ..                                                      [ 64%]
tests/test_mul.py ........                                               [ 67%]
tests/test_ne.py ........                                                [ 70%]
tests/test_neg.py ........                                               [ 73%]
tests/test_pow.py ........                                               [ 76%]
tests/test_relu.py ........                                              [ 79%]
tests/test_rsqrt.py ........                                             [ 82%]
tests/test_sigmoid.py ........                                           [ 85%]
tests/test_silu.py ........                                              [ 88%]
tests/test_sin.py ........                                               [ 91%]
tests/test_softmax.py ........                                           [ 94%]
tests/test_sub.py ........                                               [ 97%]
tests/test_tanh.py ........                                              [100%]

======================= 270 passed in 248.50s (0:04:08) ========================
```
