### PR TITLE
Add `scaled_dot_product_attention` operator

### DIFF
--- a/src/ntops/kernels/scaled_dot_product_attention.py
+++ b/src/ntops/kernels/scaled_dot_product_attention.py
@@ -1,0 +1,182 @@
+import functools
+
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Tensor
+
+BLOCK_SIZE_M = ninetoothed.block_size()
+BLOCK_SIZE_N = ninetoothed.block_size()
+
+
+def arrangement(
+    query,
+    key,
+    value,
+    present_key,
+    present_value,
+    present_key_slot,
+    present_value_slot,
+    attn_mask,
+    scale,
+    output,
+    with_kv_cache,
+    BLOCK_SIZE_M=BLOCK_SIZE_M,
+    BLOCK_SIZE_N=BLOCK_SIZE_N,
+):
+    def arrange_query_or_output(input):
+        arranged = input.tile((1, 1, BLOCK_SIZE_M, -1)).tile(
+            (1, query.shape[-3] // key.shape[-3], 1, 1)
+        )
+        arranged.dtype = arranged.dtype.squeeze((0, 2, 3))
+        arranged.dtype.dtype = arranged.dtype.dtype.squeeze((0, 1))
+
+        return arranged
+
+    def arrange_key_or_value(input):
+        arranged = (
+            input.tile((1, 1, BLOCK_SIZE_N, -1))
+            .tile((1, 1, -1, -1))
+            .expand((-1, -1, query_arranged.shape[-2], -1))
+        )
+        arranged.dtype = arranged.dtype.squeeze((0, 1, 3))
+        arranged.dtype.dtype = arranged.dtype.dtype.squeeze((0, 1))
+
+        return arranged
+
+    def arrange_present_key_or_present_value(input):
+        arranged = input.tile((1, 1, -1, -1))
+        arranged.dtype = arranged.dtype.squeeze((0, 1))
+
+        return arranged
+
+    def arrange_attn_mask(input):
+        arranged = input.tile((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N)).tile((1, 1, 1, -1))
+        arranged.dtype = arranged.dtype.squeeze((0, 1, 2))
+        arranged.dtype.dtype = arranged.dtype.dtype.squeeze((0, 1))
+
+        return arranged
+
+    query_arranged = arrange_query_or_output(query)
+    key_arranged = arrange_key_or_value(key)
+    value_arranged = arrange_key_or_value(value)
+    present_key_arranged = arrange_present_key_or_present_value(present_key)
+    present_value_arranged = arrange_present_key_or_present_value(present_value)
+    present_key_slot_arranged = arrange_present_key_or_present_value(present_key_slot)
+    present_value_slot_arranged = arrange_present_key_or_present_value(
+        present_value_slot
+    )
+    attn_mask_arranged = arrange_attn_mask(attn_mask)
+    scale_arranged = scale
+    output_arranged = arrange_query_or_output(output)
+
+    if with_kv_cache:
+        return (
+            query_arranged,
+            key_arranged,
+            value_arranged,
+            present_key_arranged,
+            present_value_arranged,
+            present_key_slot_arranged,
+            present_value_slot_arranged,
+            attn_mask_arranged,
+            scale_arranged,
+            output_arranged,
+        )
+
+    return (
+        query_arranged,
+        key_arranged,
+        value_arranged,
+        attn_mask_arranged,
+        scale_arranged,
+        output_arranged,
+    )
+
+
+def application_with_kv_cache(
+    query,
+    key,
+    value,
+    present_key,
+    present_value,
+    present_key_slot,
+    present_value_slot,
+    attn_mask,
+    scale,
+    output,
+):
+    present_key_slot = present_key  # noqa: F841
+    present_value_slot = present_value  # noqa: F841
+
+    application_without_kv_cache(query, key, value, attn_mask, scale, output)
+
+
+def application_without_kv_cache(query, key, value, attn_mask, scale, output):
+    for i in range(query.shape[0]):
+        query_i = (1.4426950408889634 * scale * query[i]).to(query[i].dtype)
+
+        acc = ntl.zeros((query_i.shape[-2], query_i.shape[-1]), dtype=ntl.float32)
+        lse = ntl.full((query_i.shape[-2],), 1, dtype=ntl.float32)
+        max = ntl.full((query_i.shape[-2],), float("-inf"), dtype=ntl.float32)
+
+        for j in range(key.shape[0]):
+            qk = ntl.dot(query_i, ntl.trans(key[j])) + attn_mask[j]
+            qk = ntl.where(key[j].offsets(-2) < key.source.shape[-2], qk, float("-inf"))
+
+            next_max = ntl.maximum(max, ntl.max(qk, 1))
+            stable_qk = ntl.exp2(qk - next_max[:, None])
+
+            alpha = ntl.exp2(max - next_max)
+            acc = acc * alpha[:, None] + ntl.dot(stable_qk.to(value[i].dtype), value[j])
+            max = next_max
+            lse = lse * alpha + ntl.sum(stable_qk, 1)
+
+        acc /= lse[:, None]
+        output[i] = acc  # noqa: F841
+
+
+@functools.cache
+def make(with_kv_cache):
+    query, key, value, attn_mask, output = (
+        Tensor(
+            4, shape_options=(None, None, None, {"constexpr": True, "upper_bound": 128})
+        )
+        for _ in range(5)
+    )
+    present_key, present_value, present_key_slot, present_value_slot = (
+        Tensor(
+            4,
+            shape_options=(
+                None,
+                None,
+                {"constexpr": True, "upper_bound": 1},
+                {"constexpr": True, "upper_bound": 128},
+            ),
+        )
+        for _ in range(4)
+    )
+    scale = Tensor(0)
+
+    if with_kv_cache:
+        application = application_with_kv_cache
+    else:
+        application = application_without_kv_cache
+
+    tensors = (
+        query,
+        key,
+        value,
+        present_key,
+        present_value,
+        present_key_slot,
+        present_value_slot,
+        attn_mask,
+        scale,
+        output,
+    )
+
+    return ninetoothed.make(
+        functools.partial(arrangement, with_kv_cache=with_kv_cache),
+        application,
+        tensors,
+    )

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -373,9 +373,11 @@ def scaled_dot_product_attention(
 ):
     # TODO: Support `dropout_p`.
     assert dropout_p == 0, "`dropout_p` is not supported yet."
-    # TODO: Support `is_causal`.
-    assert not is_causal, "`is_causal` is not supported yet."
     assert enable_gqa, "GQA must be enabled for now."
+
+    assert attn_mask is None or not is_causal, (
+        "Cannot use `attn_mask` and `is_causal` together."
+    )
 
     mask_shape = query.shape[:-1] + (key.shape[-2],)
 
@@ -413,12 +415,13 @@ def scaled_dot_product_attention(
             present_key_slot,
             present_value_slot,
             attn_mask,
+            is_causal,
             scale,
             output,
             with_attn_mask,
         )
     else:
-        kernel(query, key, value, attn_mask, scale, output, with_attn_mask)
+        kernel(query, key, value, attn_mask, is_causal, scale, output, with_attn_mask)
 
     return output
 

--- a/tests/test_scaled_dot_product_attention.py
+++ b/tests/test_scaled_dot_product_attention.py
@@ -1,0 +1,148 @@
+import itertools
+import math
+import random
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+
+
+def generate_arguments():
+    def _generate_random_size():
+        return random.randint(1, 512)
+
+    arguments = []
+
+    attn_mask_types = (None, torch.bool, torch.float32)
+    scales = (None, random.uniform(0.05, 0.5))
+    dtypes = (torch.float32, torch.float16)
+    with_kv_cache_values = (False, True)
+
+    for attn_mask_type, scale, dtype, with_kv_cache in itertools.product(
+        attn_mask_types, scales, dtypes, with_kv_cache_values
+    ):
+        batch_size = random.randint(1, 4)
+        num_heads_q = 2 ** random.randint(1, 5)
+        seq_len_q = _generate_random_size()
+        head_dim = random.choice([32, 64])
+        num_heads_kv = 2 ** random.randint(1, math.floor(math.log2(num_heads_q)))
+        seq_len_kv = _generate_random_size()
+
+        enable_gqa = True
+
+        if dtype is torch.float32:
+            atol = 0.01
+            rtol = 0.01
+        else:
+            atol = 0.025
+            rtol = 0.025
+
+        arguments.append(
+            (
+                batch_size,
+                num_heads_q,
+                seq_len_q,
+                head_dim,
+                num_heads_kv,
+                seq_len_kv,
+                attn_mask_type,
+                scale,
+                enable_gqa,
+                with_kv_cache,
+                dtype,
+                atol,
+                rtol,
+            )
+        )
+
+    return (
+        "batch_size, num_heads_q, seq_len_q, head_dim, num_heads_kv, seq_len_kv, attn_mask_type, scale, enable_gqa, with_kv_cache, dtype, atol, rtol",
+        arguments,
+    )
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(
+    batch_size,
+    num_heads_q,
+    seq_len_q,
+    head_dim,
+    num_heads_kv,
+    seq_len_kv,
+    attn_mask_type,
+    scale,
+    enable_gqa,
+    with_kv_cache,
+    dtype,
+    atol,
+    rtol,
+):
+    device = "cuda"
+
+    shape_q = (batch_size, num_heads_q, seq_len_q, head_dim)
+    shape_kv = (batch_size, num_heads_kv, seq_len_kv, head_dim)
+
+    query = torch.randn(shape_q, dtype=dtype, device=device)
+    key = torch.randn(shape_kv, dtype=dtype, device=device)
+    value = torch.randn(shape_kv, dtype=dtype, device=device)
+
+    if attn_mask_type is not None:
+        attn_mask = torch.rand(
+            (query.shape[-2], key.shape[-2]), dtype=query.dtype, device=query.device
+        )
+
+        if attn_mask_type is torch.bool:
+            attn_mask = attn_mask > 0.5
+        # TODO: Non-infinite floating-point masks may cause
+        # precision issues. Revisit here later.
+        else:
+            attn_mask = torch.where(attn_mask > 0.5, 0, float("-inf"))
+            attn_mask = attn_mask.to(query.dtype)
+    else:
+        attn_mask = None
+
+    key_cloned = key.clone()
+    value_cloned = value.clone()
+
+    def _generate_present_and_slot(tensor):
+        present = tensor[:, :, -1:, :].clone()
+        present_slot = tensor[:, :, -1:, :]
+        present_slot[...] = 0
+
+        return present, present_slot
+
+    if with_kv_cache:
+        present_key, present_key_slot = _generate_present_and_slot(key)
+        present_value, present_value_slot = _generate_present_and_slot(value)
+    else:
+        present_key = None
+        present_value = None
+        present_key_slot = None
+        present_value_slot = None
+
+    ninetoothed_output = ntops.torch.scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_mask=attn_mask,
+        scale=scale,
+        enable_gqa=enable_gqa,
+        present_key=present_key,
+        present_value=present_value,
+        present_key_slot=present_key_slot,
+        present_value_slot=present_value_slot,
+    )
+    reference_output = F.scaled_dot_product_attention(
+        query,
+        key_cloned,
+        value_cloned,
+        attn_mask=attn_mask,
+        scale=scale,
+        enable_gqa=enable_gqa,
+    )
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)

--- a/tests/test_scaled_dot_product_attention.py
+++ b/tests/test_scaled_dot_product_attention.py
@@ -17,13 +17,17 @@ def generate_arguments():
     arguments = []
 
     attn_mask_types = (None, torch.bool, torch.float32)
+    is_causal_values = (False, True)
     scales = (None, random.uniform(0.05, 0.5))
     dtypes = (torch.float32, torch.float16)
     with_kv_cache_values = (False, True)
 
-    for attn_mask_type, scale, dtype, with_kv_cache in itertools.product(
-        attn_mask_types, scales, dtypes, with_kv_cache_values
+    for attn_mask_type, is_causal, scale, dtype, with_kv_cache in itertools.product(
+        attn_mask_types, is_causal_values, scales, dtypes, with_kv_cache_values
     ):
+        if attn_mask_type is not None and is_causal:
+            continue
+
         batch_size = random.randint(1, 4)
         num_heads_q = 2 ** random.randint(1, 5)
         seq_len_q = _generate_random_size()
@@ -49,6 +53,7 @@ def generate_arguments():
                 num_heads_kv,
                 seq_len_kv,
                 attn_mask_type,
+                is_causal,
                 scale,
                 enable_gqa,
                 with_kv_cache,
@@ -59,7 +64,7 @@ def generate_arguments():
         )
 
     return (
-        "batch_size, num_heads_q, seq_len_q, head_dim, num_heads_kv, seq_len_kv, attn_mask_type, scale, enable_gqa, with_kv_cache, dtype, atol, rtol",
+        "batch_size, num_heads_q, seq_len_q, head_dim, num_heads_kv, seq_len_kv, attn_mask_type, is_causal, scale, enable_gqa, with_kv_cache, dtype, atol, rtol",
         arguments,
     )
 
@@ -74,6 +79,7 @@ def test_cuda(
     num_heads_kv,
     seq_len_kv,
     attn_mask_type,
+    is_causal,
     scale,
     enable_gqa,
     with_kv_cache,
@@ -129,6 +135,7 @@ def test_cuda(
         key,
         value,
         attn_mask=attn_mask,
+        is_causal=is_causal,
         scale=scale,
         enable_gqa=enable_gqa,
         present_key=present_key,
@@ -141,6 +148,7 @@ def test_cuda(
         key_cloned,
         value_cloned,
         attn_mask=attn_mask,
+        is_causal=is_causal,
         scale=scale,
         enable_gqa=enable_gqa,
     )


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 302 items

tests/test_abs.py ........                                               [  2%]
tests/test_add.py ........                                               [  5%]
tests/test_addmm.py ..                                                   [  5%]
tests/test_bitwise_and.py ................                               [ 11%]
tests/test_bitwise_not.py ................                               [ 16%]
tests/test_bitwise_or.py ................                                [ 21%]
tests/test_bmm.py ..                                                     [ 22%]
tests/test_clamp.py ........                                             [ 25%]
tests/test_cos.py ........                                               [ 27%]
tests/test_div.py ........                                               [ 30%]
tests/test_dropout.py ........                                           [ 33%]
tests/test_eq.py ........                                                [ 35%]
tests/test_exp.py ........                                               [ 38%]
tests/test_ge.py ........                                                [ 41%]
tests/test_gelu.py ........                                              [ 43%]
tests/test_gt.py ........                                                [ 46%]
tests/test_isinf.py ........                                             [ 49%]
tests/test_isnan.py ........                                             [ 51%]
tests/test_le.py ........                                                [ 54%]
tests/test_lt.py ........                                                [ 56%]
tests/test_mm.py ..                                                      [ 57%]
tests/test_mul.py ........                                               [ 60%]
tests/test_ne.py ........                                                [ 62%]
tests/test_neg.py ........                                               [ 65%]
tests/test_pow.py ........                                               [ 68%]
tests/test_relu.py ........                                              [ 70%]
tests/test_rsqrt.py ........                                             [ 73%]
tests/test_scaled_dot_product_attention.py ............................. [ 83%]
...                                                                      [ 84%]
tests/test_sigmoid.py ........                                           [ 86%]
tests/test_silu.py ........                                              [ 89%]
tests/test_sin.py ........                                               [ 92%]
tests/test_softmax.py ........                                           [ 94%]
tests/test_sub.py ........                                               [ 97%]
tests/test_tanh.py ........                                              [100%]

======================= 302 passed in 1761.04s (0:29:21) =======================
```
