### PR TITLE
Remove debug `print` from `test_dropout.py`

### DIFF
--- a/tests/test_dropout.py
+++ b/tests/test_dropout.py
@@ -30,8 +30,6 @@ def test_cuda(shape, dtype, atol, rtol):
         reference_output.nonzero().numel() / reference_output.ndim / input.numel()
     )
 
-    print(abs(ninetoothed_non_zero_ratio - reference_non_zero_ratio))
-
     assert abs(ninetoothed_non_zero_ratio - reference_non_zero_ratio) < 0.1
 
     assert torch.allclose(


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 302 items

tests/test_abs.py ........                                               [  2%]
tests/test_add.py ........                                               [  5%]
tests/test_addmm.py ..                                                   [  5%]
tests/test_bitwise_and.py ................                               [ 11%]
tests/test_bitwise_not.py ................                               [ 16%]
tests/test_bitwise_or.py ................                                [ 21%]
tests/test_bmm.py ..                                                     [ 22%]
tests/test_clamp.py ........                                             [ 25%]
tests/test_cos.py ........                                               [ 27%]
tests/test_div.py ........                                               [ 30%]
tests/test_dropout.py ........                                           [ 33%]
tests/test_eq.py ........                                                [ 35%]
tests/test_exp.py ........                                               [ 38%]
tests/test_ge.py ........                                                [ 41%]
tests/test_gelu.py ........                                              [ 43%]
tests/test_gt.py ........                                                [ 46%]
tests/test_isinf.py ........                                             [ 49%]
tests/test_isnan.py ........                                             [ 51%]
tests/test_le.py ........                                                [ 54%]
tests/test_lt.py ........                                                [ 56%]
tests/test_mm.py ..                                                      [ 57%]
tests/test_mul.py ........                                               [ 60%]
tests/test_ne.py ........                                                [ 62%]
tests/test_neg.py ........                                               [ 65%]
tests/test_pow.py ........                                               [ 68%]
tests/test_relu.py ........                                              [ 70%]
tests/test_rsqrt.py ........                                             [ 73%]
tests/test_scaled_dot_product_attention.py ............................. [ 83%]
...                                                                      [ 84%]
tests/test_sigmoid.py ........                                           [ 86%]
tests/test_silu.py ........                                              [ 89%]
tests/test_sin.py ........                                               [ 92%]
tests/test_softmax.py ........                                           [ 94%]
tests/test_sub.py ........                                               [ 97%]
tests/test_tanh.py ........                                              [100%]

======================= 302 passed in 655.69s (0:10:55) ========================
```
