### PR TITLE
Refactor kernels to use `premake` instead of `make`

### DIFF
--- a/src/ntops/kernels/abs.py
+++ b/src/ntops/kernels/abs.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -11,6 +10,9 @@ def application(input, output):
     output = ntl.abs(input)  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/add.py
+++ b/src/ntops/kernels/add.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,14 @@ def application(input, other, alpha, output):
     output = input + alpha * other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(0), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(0, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/addmm.py
+++ b/src/ntops/kernels/addmm.py
@@ -14,10 +14,19 @@ def arrangement(
     beta,
     alpha,
     output,
-    block_size_m=mm.BLOCK_SIZE_M,
-    block_size_n=mm.BLOCK_SIZE_N,
-    block_size_k=mm.BLOCK_SIZE_K,
+    block_size_m=None,
+    block_size_n=None,
+    block_size_k=None,
 ):
+    if block_size_m is None:
+        block_size_m = mm.BLOCK_SIZE_M
+
+    if block_size_n is None:
+        block_size_n = mm.BLOCK_SIZE_N
+
+    if block_size_k is None:
+        block_size_k = mm.BLOCK_SIZE_K
+
     _, _, input_arranged = mm.arrangement(
         x,
         y,

--- a/src/ntops/kernels/addmm.py
+++ b/src/ntops/kernels/addmm.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -47,8 +46,21 @@ def application(input, x, y, beta, alpha, output):
     output = beta * input + alpha * mm_output
 
 
-@functools.cache
-def make():
-    tensors = (Tensor(2), Tensor(2), Tensor(2), Tensor(0), Tensor(0), Tensor(2))
+def premake(dtype=None, block_size_m=None, block_size_n=None, block_size_k=None):
+    arrangement_ = functools.partial(
+        arrangement,
+        block_size_m=block_size_m,
+        block_size_n=block_size_n,
+        block_size_k=block_size_k,
+    )
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(2, dtype=dtype),
+        Tensor(2, dtype=dtype),
+        Tensor(2, dtype=dtype),
+        Tensor(0, dtype=dtype),
+        Tensor(0, dtype=dtype),
+        Tensor(2, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/addmm.py
+++ b/src/ntops/kernels/addmm.py
@@ -7,8 +7,25 @@ from ninetoothed import Tensor
 import ntops.kernels.mm as mm
 
 
-def arrangement(input, x, y, beta, alpha, output):
-    _, _, input_arranged = mm.arrangement(x, y, input)
+def arrangement(
+    input,
+    x,
+    y,
+    beta,
+    alpha,
+    output,
+    block_size_m=mm.BLOCK_SIZE_M,
+    block_size_n=mm.BLOCK_SIZE_N,
+    block_size_k=mm.BLOCK_SIZE_K,
+):
+    _, _, input_arranged = mm.arrangement(
+        x,
+        y,
+        input,
+        block_size_m=block_size_m,
+        block_size_n=block_size_n,
+        block_size_k=block_size_k,
+    )
 
     x_arranged, y_arranged, output_arranged = mm.arrangement(x, y, output)
 

--- a/src/ntops/kernels/bitwise_and.py
+++ b/src/ntops/kernels/bitwise_and.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,13 @@ def application(input, other, output):
     output = input & other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/bitwise_not.py
+++ b/src/ntops/kernels/bitwise_not.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -15,10 +14,11 @@ def logical_application(input, output):
     output = ntl.where(input, False, True)  # noqa: F841
 
 
-@functools.cache
-def make(ndim, logical=False):
-    tensors = (Tensor(ndim), Tensor(ndim))
+def premake(ndim, logical=False, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
     application = logical_application if logical else bitwise_application
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/bitwise_or.py
+++ b/src/ntops/kernels/bitwise_or.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,13 @@ def application(input, other, output):
     output = input | other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/bmm.py
+++ b/src/ntops/kernels/bmm.py
@@ -7,13 +7,17 @@ from ntops.kernels.mm import BLOCK_SIZE_K, BLOCK_SIZE_M, BLOCK_SIZE_N, applicati
 
 
 def arrangement(
-    input,
-    other,
-    output,
-    block_size_m=BLOCK_SIZE_M,
-    block_size_n=BLOCK_SIZE_N,
-    block_size_k=BLOCK_SIZE_K,
+    input, other, output, block_size_m=None, block_size_n=None, block_size_k=None
 ):
+    if block_size_m is None:
+        block_size_m = BLOCK_SIZE_M
+
+    if block_size_n is None:
+        block_size_n = BLOCK_SIZE_N
+
+    if block_size_k is None:
+        block_size_k = BLOCK_SIZE_K
+
     output_arranged = output.tile((1, block_size_m, block_size_n))
     output_arranged.dtype = output_arranged.dtype.squeeze(0)
 

--- a/src/ntops/kernels/bmm.py
+++ b/src/ntops/kernels/bmm.py
@@ -6,17 +6,24 @@ from ninetoothed import Tensor
 from ntops.kernels.mm import BLOCK_SIZE_K, BLOCK_SIZE_M, BLOCK_SIZE_N, application
 
 
-def arrangement(input, other, output):
-    output_arranged = output.tile((1, BLOCK_SIZE_M, BLOCK_SIZE_N))
+def arrangement(
+    input,
+    other,
+    output,
+    block_size_m=BLOCK_SIZE_M,
+    block_size_n=BLOCK_SIZE_N,
+    block_size_k=BLOCK_SIZE_K,
+):
+    output_arranged = output.tile((1, block_size_m, block_size_n))
     output_arranged.dtype = output_arranged.dtype.squeeze(0)
 
-    input_arranged = input.tile((1, BLOCK_SIZE_M, BLOCK_SIZE_K))
+    input_arranged = input.tile((1, block_size_m, block_size_k))
     input_arranged = input_arranged.tile((1, 1, -1))
     input_arranged = input_arranged.expand((-1, -1, output_arranged.shape[-1]))
     input_arranged.dtype = input_arranged.dtype.squeeze((0, 1))
     input_arranged.dtype.dtype = input_arranged.dtype.dtype.squeeze(0)
 
-    other_arranged = other.tile((1, BLOCK_SIZE_K, BLOCK_SIZE_N))
+    other_arranged = other.tile((1, block_size_k, block_size_n))
     other_arranged = other_arranged.tile((1, -1, 1))
     other_arranged = other_arranged.expand((-1, output_arranged.shape[-2], -1))
     other_arranged.dtype = other_arranged.dtype.squeeze((0, 2))

--- a/src/ntops/kernels/bmm.py
+++ b/src/ntops/kernels/bmm.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.mm import BLOCK_SIZE_K, BLOCK_SIZE_M, BLOCK_SIZE_N, application
@@ -36,6 +35,14 @@ def arrangement(
     return input_arranged, other_arranged, output_arranged
 
 
-@functools.cache
-def make():
-    return ninetoothed.make(arrangement, application, (Tensor(3), Tensor(3), Tensor(3)))
+def premake(dtype=None, block_size_m=None, block_size_n=None, block_size_k=None):
+    arrangement_ = functools.partial(
+        arrangement,
+        block_size_m=block_size_m,
+        block_size_n=block_size_n,
+        block_size_k=block_size_k,
+    )
+
+    tensors = (Tensor(3, dtype=dtype), Tensor(3, dtype=dtype), Tensor(3, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/clamp.py
+++ b/src/ntops/kernels/clamp.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -11,8 +10,14 @@ def application(input, min_val, max_val, output):
     output = ntl.clamp(input, min_val, max_val)  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/cos.py
+++ b/src/ntops/kernels/cos.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -11,6 +10,9 @@ def application(input, output):
     output = ntl.cos(input)  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/div.py
+++ b/src/ntops/kernels/div.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -19,8 +18,9 @@ def floor_application(input, other, output):
     output = ntl.floor(input / other)  # noqa: F841
 
 
-@functools.cache
-def make(ndim, rounding_mode):
+def premake(ndim, rounding_mode, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
     if rounding_mode == "trunc":
         application = trunc_application
     elif rounding_mode == "floor":
@@ -28,6 +28,10 @@ def make(ndim, rounding_mode):
     else:
         application = default_application
 
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
 
-    return ninetoothed.make(arrangement, application, tensors)
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/dropout.py
+++ b/src/ntops/kernels/dropout.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -11,8 +10,14 @@ def application(input, p, seed, output):
     output = ntl.where(ntl.rand(seed, input.offsets()) > p, input / (1 - p), 0)  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(0), Tensor(0), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(0, dtype=dtype),
+        Tensor(0, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/element_wise.py
+++ b/src/ntops/kernels/element_wise.py
@@ -1,7 +1,10 @@
 import ninetoothed
 
 
-def arrangement(*tensors, block_size=ninetoothed.block_size()):
+def arrangement(*tensors, block_size=None):
+    if block_size is None:
+        block_size = ninetoothed.block_size()
+
     ndim = max(tensor.ndim for tensor in tensors)
 
     assert all(tensor.ndim == ndim or tensor.ndim == 0 for tensor in tensors)

--- a/src/ntops/kernels/eq.py
+++ b/src/ntops/kernels/eq.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,13 @@ def application(input, other, output):
     output = input == other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/exp.py
+++ b/src/ntops/kernels/exp.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -11,6 +10,9 @@ def application(input, output):
     output = ntl.exp(input)  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/ge.py
+++ b/src/ntops/kernels/ge.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,13 @@ def application(input, other, output):
     output = input >= other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/gelu.py
+++ b/src/ntops/kernels/gelu.py
@@ -1,7 +1,6 @@
 import functools
 import math
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -27,13 +26,14 @@ def tanh_application(input, output):
     )
 
 
-@functools.cache
-def make(ndim, approximate):
+def premake(ndim, approximate, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
     if approximate == "tanh":
         application = tanh_application
     else:
         application = default_application
 
-    tensors = (Tensor(ndim), Tensor(ndim))
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
 
-    return ninetoothed.make(arrangement, application, tensors)
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/gt.py
+++ b/src/ntops/kernels/gt.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,13 @@ def application(input, other, output):
     output = input > other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/isinf.py
+++ b/src/ntops/kernels/isinf.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -12,6 +11,9 @@ def application(input, output):
     output = pos_result or neg_result  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/isnan.py
+++ b/src/ntops/kernels/isnan.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,6 +9,9 @@ def application(input, output):
     output = input != input  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/le.py
+++ b/src/ntops/kernels/le.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,13 @@ def application(input, other, output):
     output = input <= other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/lt.py
+++ b/src/ntops/kernels/lt.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,13 @@ def application(input, other, output):
     output = input < other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/mm.py
+++ b/src/ntops/kernels/mm.py
@@ -45,6 +45,14 @@ def application(input, other, output):
     output = accumulator
 
 
-@functools.cache
-def make():
-    return ninetoothed.make(arrangement, application, (Tensor(2), Tensor(2), Tensor(2)))
+def premake(dtype=None, block_size_m=None, block_size_n=None, block_size_k=None):
+    arrangement_ = functools.partial(
+        arrangement,
+        block_size_m=block_size_m,
+        block_size_n=block_size_n,
+        block_size_k=block_size_k,
+    )
+
+    tensors = (Tensor(2, dtype=dtype), Tensor(2, dtype=dtype), Tensor(2, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/mm.py
+++ b/src/ntops/kernels/mm.py
@@ -10,13 +10,17 @@ BLOCK_SIZE_K = ninetoothed.block_size()
 
 
 def arrangement(
-    input,
-    other,
-    output,
-    block_size_m=BLOCK_SIZE_M,
-    block_size_n=BLOCK_SIZE_N,
-    block_size_k=BLOCK_SIZE_K,
+    input, other, output, block_size_m=None, block_size_n=None, block_size_k=None
 ):
+    if block_size_m is None:
+        block_size_m = BLOCK_SIZE_M
+
+    if block_size_n is None:
+        block_size_n = BLOCK_SIZE_N
+
+    if block_size_k is None:
+        block_size_k = BLOCK_SIZE_K
+
     output_arranged = output.tile((block_size_m, block_size_n))
 
     input_arranged = input.tile((block_size_m, block_size_k))

--- a/src/ntops/kernels/mm.py
+++ b/src/ntops/kernels/mm.py
@@ -9,15 +9,22 @@ BLOCK_SIZE_N = ninetoothed.block_size()
 BLOCK_SIZE_K = ninetoothed.block_size()
 
 
-def arrangement(input, other, output):
-    output_arranged = output.tile((BLOCK_SIZE_M, BLOCK_SIZE_N))
+def arrangement(
+    input,
+    other,
+    output,
+    block_size_m=BLOCK_SIZE_M,
+    block_size_n=BLOCK_SIZE_N,
+    block_size_k=BLOCK_SIZE_K,
+):
+    output_arranged = output.tile((block_size_m, block_size_n))
 
-    input_arranged = input.tile((BLOCK_SIZE_M, BLOCK_SIZE_K))
+    input_arranged = input.tile((block_size_m, block_size_k))
     input_arranged = input_arranged.tile((1, -1))
     input_arranged = input_arranged.expand((-1, output_arranged.shape[1]))
     input_arranged.dtype = input_arranged.dtype.squeeze(0)
 
-    other_arranged = other.tile((BLOCK_SIZE_K, BLOCK_SIZE_N))
+    other_arranged = other.tile((block_size_k, block_size_n))
     other_arranged = other_arranged.tile((-1, 1))
     other_arranged = other_arranged.expand((output_arranged.shape[0], -1))
     other_arranged.dtype = other_arranged.dtype.squeeze(1)

--- a/src/ntops/kernels/mul.py
+++ b/src/ntops/kernels/mul.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,13 @@ def application(input, other, output):
     output = input * other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/ne.py
+++ b/src/ntops/kernels/ne.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,13 @@ def application(input, other, output):
     output = input != other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/neg.py
+++ b/src/ntops/kernels/neg.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,9 @@ def application(input, output):
     output = -input  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/pow.py
+++ b/src/ntops/kernels/pow.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 from ninetoothed.language import libdevice
 
@@ -11,8 +10,13 @@ def application(input, exponent, output):
     output = libdevice.pow(input, exponent)  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/relu.py
+++ b/src/ntops/kernels/relu.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,9 @@ def application(input, output):
     output = max(0.0, input)  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/rsqrt.py
+++ b/src/ntops/kernels/rsqrt.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -11,6 +10,9 @@ def application(input, output):
     output = ntl.rsqrt(ntl.cast(input, ntl.float32))  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/scaled_dot_product_attention.py
+++ b/src/ntops/kernels/scaled_dot_product_attention.py
@@ -22,11 +22,11 @@ def arrangement(
     output,
     with_attn_mask,
     with_kv_cache,
-    BLOCK_SIZE_M=BLOCK_SIZE_M,
-    BLOCK_SIZE_N=BLOCK_SIZE_N,
+    block_size_m=BLOCK_SIZE_M,
+    block_size_n=BLOCK_SIZE_N,
 ):
     def arrange_query_or_output(input):
-        arranged = input.tile((1, 1, BLOCK_SIZE_M, -1)).tile(
+        arranged = input.tile((1, 1, block_size_m, -1)).tile(
             (1, query.shape[-3] // key.shape[-3], 1, 1)
         )
         arranged.dtype = arranged.dtype.squeeze((0, 2, 3))
@@ -36,7 +36,7 @@ def arrangement(
 
     def arrange_key_or_value(input):
         arranged = (
-            input.tile((1, 1, BLOCK_SIZE_N, -1))
+            input.tile((1, 1, block_size_n, -1))
             .tile((1, 1, -1, -1))
             .expand((-1, -1, query_arranged.shape[-2], -1))
         )
@@ -46,13 +46,13 @@ def arrangement(
         return arranged
 
     def arrange_present_key_or_present_value(input):
-        arranged = input.tile((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N))
+        arranged = input.tile((1, 1, block_size_m, block_size_n))
         arranged.dtype = arranged.dtype.squeeze((0, 1))
 
         return arranged
 
     def arrange_attn_mask(input):
-        arranged = input.tile((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N)).tile((1, 1, 1, -1))
+        arranged = input.tile((1, 1, block_size_m, block_size_n)).tile((1, 1, 1, -1))
         arranged.dtype = arranged.dtype.squeeze((0, 1, 2))
         arranged.dtype.dtype = arranged.dtype.dtype.squeeze((0, 1))
 

--- a/src/ntops/kernels/scaled_dot_product_attention.py
+++ b/src/ntops/kernels/scaled_dot_product_attention.py
@@ -22,8 +22,8 @@ def arrangement(
     output,
     with_attn_mask,
     with_kv_cache,
-    block_size_m=BLOCK_SIZE_M,
-    block_size_n=BLOCK_SIZE_N,
+    block_size_m=None,
+    block_size_n=None,
 ):
     def arrange_query_or_output(input):
         arranged = input.tile((1, 1, block_size_m, -1)).tile(
@@ -57,6 +57,12 @@ def arrangement(
         arranged.dtype.dtype = arranged.dtype.dtype.squeeze((0, 1))
 
         return arranged
+
+    if block_size_m is None:
+        block_size_m = BLOCK_SIZE_M
+
+    if block_size_n is None:
+        block_size_n = BLOCK_SIZE_N
 
     query_arranged = arrange_query_or_output(query)
     key_arranged = arrange_key_or_value(key)

--- a/src/ntops/kernels/sigmoid.py
+++ b/src/ntops/kernels/sigmoid.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -11,6 +10,9 @@ def application(input, output):
     output = ntl.sigmoid(input)  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/silu.py
+++ b/src/ntops/kernels/silu.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -11,8 +10,9 @@ def application(input, output):
     output = input / (1 + ntl.exp(-ntl.cast(input, ntl.float32)))  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/sin.py
+++ b/src/ntops/kernels/sin.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -11,6 +10,9 @@ def application(input, output):
     output = ntl.sin(input)  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/softmax.py
+++ b/src/ntops/kernels/softmax.py
@@ -60,13 +60,14 @@ def application(input, output):
         output[i] = numerator / denominator
 
 
-@functools.cache
-def make(ndim, dim):
-    return ninetoothed.make(
-        functools.partial(arrangement, dim=dim),
-        application,
-        (
-            Tensor(ndim, other=float("-inf"), shape_options={"constexpr": True}),
-            Tensor(ndim),
+def premake(ndim, dim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, dim=dim, block_size=block_size)
+
+    tensors = (
+        Tensor(
+            ndim, dtype=dtype, other=float("-inf"), shape_options={"constexpr": True}
         ),
+        Tensor(ndim, dtype=dtype),
     )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/softmax.py
+++ b/src/ntops/kernels/softmax.py
@@ -7,7 +7,7 @@ from ninetoothed import Tensor
 BLOCK_SIZE = ninetoothed.block_size()
 
 
-def arrangement(input, output, dim):
+def arrangement(input, output, dim, block_size=BLOCK_SIZE):
     assert input.ndim == output.ndim
 
     def create_axis_tile_shape(dim, dim_block):
@@ -28,7 +28,7 @@ def arrangement(input, output, dim):
         )
         return input_arranged
 
-    inner_block_shape = create_axis_tile_shape(dim, BLOCK_SIZE)
+    inner_block_shape = create_axis_tile_shape(dim, block_size)
     outer_block_shape = create_axis_tile_shape(dim, -1)
 
     return arrange(input), arrange(output)

--- a/src/ntops/kernels/softmax.py
+++ b/src/ntops/kernels/softmax.py
@@ -7,7 +7,7 @@ from ninetoothed import Tensor
 BLOCK_SIZE = ninetoothed.block_size()
 
 
-def arrangement(input, output, dim, block_size=BLOCK_SIZE):
+def arrangement(input, output, dim, block_size=None):
     assert input.ndim == output.ndim
 
     def create_axis_tile_shape(dim, dim_block):
@@ -27,6 +27,9 @@ def arrangement(input, output, dim, block_size=BLOCK_SIZE):
             tuple(d for d in range(input.ndim) if d != dim)
         )
         return input_arranged
+
+    if block_size is None:
+        block_size = BLOCK_SIZE
 
     inner_block_shape = create_axis_tile_shape(dim, block_size)
     outer_block_shape = create_axis_tile_shape(dim, -1)

--- a/src/ntops/kernels/sub.py
+++ b/src/ntops/kernels/sub.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 from ninetoothed import Tensor
 
 from ntops.kernels.element_wise import arrangement
@@ -10,8 +9,14 @@ def application(input, other, alpha, output):
     output = input - alpha * other  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    tensors = (Tensor(ndim), Tensor(ndim), Tensor(0), Tensor(ndim))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
 
-    return ninetoothed.make(arrangement, application, tensors)
+    tensors = (
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(0, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/kernels/tanh.py
+++ b/src/ntops/kernels/tanh.py
@@ -1,6 +1,5 @@
 import functools
 
-import ninetoothed
 import ninetoothed.language as ntl
 from ninetoothed import Tensor
 
@@ -13,6 +12,9 @@ def application(input, output):
     output = (exp_input - exp_neg_input) / (exp_input + exp_neg_input)  # noqa: F841
 
 
-@functools.cache
-def make(ndim):
-    return ninetoothed.make(arrangement, application, (Tensor(ndim), Tensor(ndim)))
+def premake(ndim, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
+    tensors = (Tensor(ndim, dtype=dtype), Tensor(ndim, dtype=dtype))
+
+    return arrangement_, application, tensors

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -1,6 +1,8 @@
+import functools
 import math
 import random
 
+import ninetoothed
 import torch
 
 import ntops.kernels.abs
@@ -43,7 +45,7 @@ def abs(input, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.abs.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.abs.premake, input.ndim)
 
     kernel(input, out)
 
@@ -54,7 +56,7 @@ def add(input, other, *, alpha=1, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.add.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.add.premake, input.ndim)
 
     kernel(input, other, alpha, out)
 
@@ -68,7 +70,7 @@ def addmm(input, mat1, mat2, *, beta=1, alpha=1, out=None):
     if out is None:
         out = torch.empty((m, n), dtype=input.dtype, device=input.device)
 
-    kernel = ntops.kernels.addmm.make()
+    kernel = _cached_make(ntops.kernels.addmm.premake)
 
     kernel(input, mat1, mat2, beta, alpha, out)
 
@@ -79,7 +81,7 @@ def bitwise_and(input, other, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.bitwise_and.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.bitwise_and.premake, input.ndim)
 
     kernel(input, other, out)
 
@@ -90,7 +92,9 @@ def bitwise_not(input, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.bitwise_not.make(input.ndim, input.dtype == torch.bool)
+    kernel = _cached_make(
+        ntops.kernels.bitwise_not.premake, input.ndim, input.dtype == torch.bool
+    )
 
     kernel(input, out)
 
@@ -101,7 +105,7 @@ def bitwise_or(input, other, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.bitwise_or.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.bitwise_or.premake, input.ndim)
 
     kernel(input, other, out)
 
@@ -115,7 +119,7 @@ def bmm(input, mat2, *, out=None):
     if out is None:
         out = torch.empty((b, m, n), dtype=input.dtype, device=input.device)
 
-    kernel = ntops.kernels.bmm.make()
+    kernel = _cached_make(ntops.kernels.bmm.premake)
 
     kernel(input, mat2, out)
 
@@ -126,7 +130,7 @@ def clamp(input, min=None, max=None, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.clamp.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.clamp.premake, input.ndim)
 
     kernel(input, min, max, out)
 
@@ -137,7 +141,7 @@ def cos(input, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.cos.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.cos.premake, input.ndim)
 
     kernel(input, out)
 
@@ -148,7 +152,7 @@ def div(input, other, *, rounding_mode=None, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.div.make(input.ndim, rounding_mode)
+    kernel = _cached_make(ntops.kernels.div.premake, input.ndim, rounding_mode)
 
     kernel(input, other, out)
 
@@ -169,7 +173,7 @@ def dropout(input, p=0.5, training=True, inplace=False):
     else:
         output = torch.empty_like(input)
 
-    kernel = ntops.kernels.dropout.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.dropout.premake, input.ndim)
 
     kernel(input, p, seed, output)
 
@@ -180,7 +184,7 @@ def exp(input, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.exp.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.exp.premake, input.ndim)
 
     kernel(input, out)
 
@@ -191,7 +195,7 @@ def ge(input, other, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.ge.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.ge.premake, input.ndim)
 
     kernel(input, other, out)
 
@@ -202,7 +206,7 @@ def eq(input, other, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.eq.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.eq.premake, input.ndim)
 
     kernel(input, other, out)
 
@@ -212,7 +216,7 @@ def eq(input, other, *, out=None):
 def gelu(input, approximate="none"):
     output = torch.empty_like(input)
 
-    kernel = ntops.kernels.gelu.make(input.ndim, approximate)
+    kernel = _cached_make(ntops.kernels.gelu.premake, input.ndim, approximate)
 
     kernel(input, output)
 
@@ -223,7 +227,7 @@ def gt(input, other, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.gt.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.gt.premake, input.ndim)
 
     kernel(input, other, out)
 
@@ -233,7 +237,7 @@ def gt(input, other, *, out=None):
 def isinf(input):
     output = torch.empty_like(input)
 
-    kernel = ntops.kernels.isinf.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.isinf.premake, input.ndim)
 
     kernel(input, output)
 
@@ -243,7 +247,7 @@ def isinf(input):
 def isnan(input):
     output = torch.empty_like(input)
 
-    kernel = ntops.kernels.isnan.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.isnan.premake, input.ndim)
 
     kernel(input, output)
 
@@ -257,7 +261,7 @@ def mm(input, mat2, *, out=None):
     if out is None:
         out = torch.empty((m, n), dtype=input.dtype, device=input.device)
 
-    kernel = ntops.kernels.mm.make()
+    kernel = _cached_make(ntops.kernels.mm.premake)
 
     kernel(input, mat2, out)
 
@@ -268,7 +272,7 @@ def le(input, other, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.le.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.le.premake, input.ndim)
 
     kernel(input, other, out)
 
@@ -279,7 +283,7 @@ def lt(input, other, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.lt.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.lt.premake, input.ndim)
 
     kernel(input, other, out)
 
@@ -290,7 +294,7 @@ def mul(input, other, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.mul.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.mul.premake, input.ndim)
 
     kernel(input, other, out)
 
@@ -301,7 +305,7 @@ def ne(input, other, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.ne.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.ne.premake, input.ndim)
 
     kernel(input, other, out)
 
@@ -312,7 +316,7 @@ def neg(input, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.neg.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.neg.premake, input.ndim)
 
     kernel(input, out)
 
@@ -323,7 +327,7 @@ def pow(input, exponent, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.pow.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.pow.premake, input.ndim)
 
     kernel(input, exponent, out)
 
@@ -336,7 +340,7 @@ def relu(input, inplace=False):
     else:
         output = torch.empty_like(input)
 
-    kernel = ntops.kernels.relu.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.relu.premake, input.ndim)
 
     kernel(input, output)
 
@@ -347,7 +351,7 @@ def rsqrt(input, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.rsqrt.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.rsqrt.premake, input.ndim)
 
     kernel(input, out)
 
@@ -415,7 +419,9 @@ def scaled_dot_product_attention(
 
     output = torch.empty_like(query, dtype=value.dtype)
 
-    kernel = ntops.kernels.scaled_dot_product_attention.make(with_kv_cache)
+    kernel = _cached_make(
+        ntops.kernels.scaled_dot_product_attention.premake, with_kv_cache
+    )
 
     if with_kv_cache:
         kernel(
@@ -442,7 +448,7 @@ def sigmoid(input, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.sigmoid.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.sigmoid.premake, input.ndim)
 
     kernel(input, out)
 
@@ -455,7 +461,7 @@ def silu(input, inplace=False):
     else:
         output = torch.empty_like(input)
 
-    kernel = ntops.kernels.silu.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.silu.premake, input.ndim)
 
     kernel(input, output)
 
@@ -466,7 +472,7 @@ def sin(input, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.sin.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.sin.premake, input.ndim)
 
     kernel(input, out)
 
@@ -478,7 +484,7 @@ def softmax(input, dim, dtype=None):
 
     output = torch.empty_like(input, dtype=tensor_dtype)
 
-    kernel = ntops.kernels.softmax.make(input.ndim, dim)
+    kernel = _cached_make(ntops.kernels.softmax.premake, input.ndim, dim)
 
     kernel(input, output)
 
@@ -489,7 +495,7 @@ def sub(input, other, *, alpha=1, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.sub.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.sub.premake, input.ndim)
 
     kernel(input, other, alpha, out)
 
@@ -500,8 +506,13 @@ def tanh(input, *, out=None):
     if out is None:
         out = torch.empty_like(input)
 
-    kernel = ntops.kernels.tanh.make(input.ndim)
+    kernel = _cached_make(ntops.kernels.tanh.premake, input.ndim)
 
     kernel(input, out)
 
     return out
+
+
+@functools.cache
+def _cached_make(premake, *args, **keywords):
+    return ninetoothed.make(*premake(*args, **keywords))


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 302 items

tests/test_abs.py ........                                               [  2%]
tests/test_add.py ........                                               [  5%]
tests/test_addmm.py ..                                                   [  5%]
tests/test_bitwise_and.py ................                               [ 11%]
tests/test_bitwise_not.py ................                               [ 16%]
tests/test_bitwise_or.py ................                                [ 21%]
tests/test_bmm.py ..                                                     [ 22%]
tests/test_clamp.py ........                                             [ 25%]
tests/test_cos.py ........                                               [ 27%]
tests/test_div.py ........                                               [ 30%]
tests/test_dropout.py ........                                           [ 33%]
tests/test_eq.py ........                                                [ 35%]
tests/test_exp.py ........                                               [ 38%]
tests/test_ge.py ........                                                [ 41%]
tests/test_gelu.py ........                                              [ 43%]
tests/test_gt.py ........                                                [ 46%]
tests/test_isinf.py ........                                             [ 49%]
tests/test_isnan.py ........                                             [ 51%]
tests/test_le.py ........                                                [ 54%]
tests/test_lt.py ........                                                [ 56%]
tests/test_mm.py ..                                                      [ 57%]
tests/test_mul.py ........                                               [ 60%]
tests/test_ne.py ........                                                [ 62%]
tests/test_neg.py ........                                               [ 65%]
tests/test_pow.py ........                                               [ 68%]
tests/test_relu.py ........                                              [ 70%]
tests/test_rsqrt.py ........                                             [ 73%]
tests/test_scaled_dot_product_attention.py ............................. [ 83%]
...                                                                      [ 84%]
tests/test_sigmoid.py ........                                           [ 86%]
tests/test_silu.py ........                                              [ 89%]
tests/test_sin.py ........                                               [ 92%]
tests/test_softmax.py ........                                           [ 94%]
tests/test_sub.py ........                                               [ 97%]
tests/test_tanh.py ........                                              [100%]

======================= 302 passed in 245.99s (0:04:05) ========================
```
