### PR TITLE
Develop rotary position embedding

### DIFF
--- a/src/ntops/kernels/rotary_position_embedding.py
+++ b/src/ntops/kernels/rotary_position_embedding.py
@@ -1,0 +1,66 @@
+import functools
+
+from ninetoothed import Tensor
+
+
+def arrangement(input, sin_table, cos_table, output, interleaved=True):
+    emb_dim = input.shape[-1]
+    tile_shape = (1, 1, 1, emb_dim // 2)
+
+    if interleaved:
+        strides = (-1, -1, -1, 1)
+        dilation = (1, 1, 1, 2)
+    else:
+        strides = None
+        dilation = None
+
+    def _arrange_input_or_output(tensor):
+        tensor_arranged = tensor.tile(tile_shape, strides=strides, dilation=dilation)
+        tensor_arranged = tensor_arranged.tile((1, 1, 1, -1))
+        tensor_arranged.dtype = tensor_arranged.dtype.squeeze((0, 1, 2))
+        tensor_arranged.dtype.dtype = tensor_arranged.dtype.dtype.squeeze((0, 1, 2))
+
+        return tensor_arranged
+
+    def _arrange_table(table):
+        table_arranged = table.tile(tile_shape)
+        table_arranged.dtype = table_arranged.dtype.squeeze((0, 1, 2))
+
+        return table_arranged
+
+    input_arranged = _arrange_input_or_output(input)
+    sin_table_arranged = _arrange_table(sin_table)
+    cos_table_arranged = _arrange_table(cos_table)
+    output_arranged = _arrange_input_or_output(output)
+
+    return input_arranged, sin_table_arranged, cos_table_arranged, output_arranged
+
+
+def application(input, sin_table, cos_table, output):
+    sin_table_loaded = sin_table
+    cos_table_loaded = cos_table
+
+    input_0 = input[0]
+    input_1 = input[1]
+
+    output[0] = input_0 * cos_table_loaded - input_1 * sin_table_loaded
+    output[1] = input_0 * sin_table_loaded + input_1 * cos_table_loaded
+
+
+def premake(ndim, emb_dim=None, dtype=None, interleaved=True):
+    arrangement_ = functools.partial(arrangement, interleaved=interleaved)
+
+    shape_options = (None, None, None, {"constexpr": True, "upper_bound": 128})
+
+    tensors = (
+        Tensor(ndim, dtype=dtype, shape_options=shape_options),
+        Tensor(ndim, dtype=dtype, shape_options=shape_options),
+        Tensor(ndim, dtype=dtype, shape_options=shape_options),
+        Tensor(ndim, dtype=dtype, shape_options=shape_options),
+    )
+
+    if emb_dim is not None:
+        for tensor in tensors:
+            tensor.shape = tensor.shape[:-1] + (emb_dim,)
+
+    return arrangement_, application, tensors

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -538,5 +538,12 @@ def tanh(input, *, out=None):
 
 
 @functools.cache
-def _cached_make(premake, *args, **keywords):
-    return ninetoothed.make(*premake(*args, **keywords))
+def _cached_make(
+    premake, *args, num_warps=None, num_stages=None, max_num_configs=None, **keywords
+):
+    return ninetoothed.make(
+        *premake(*args, **keywords),
+        num_warps=num_warps,
+        num_stages=num_stages,
+        max_num_configs=max_num_configs,
+    )

--- a/tests/test_rotary_position_embedding.py
+++ b/tests/test_rotary_position_embedding.py
@@ -1,0 +1,81 @@
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+
+
+def _torch_rotary_position_embedding(input, sin_table, cos_table, interleaved=True):
+    batch_size, seq_len, num_heads, emb_dim = input.shape
+
+    assert emb_dim % 2 == 0, "The embedding dimension must be even."
+
+    sin_table = sin_table[None, :, None, :]
+    cos_table = cos_table[None, :, None, :]
+
+    if interleaved:
+        pair_wise_input = input.view(batch_size, seq_len, num_heads, emb_dim // 2, 2)
+        input_0, input_1 = pair_wise_input[..., 0], pair_wise_input[..., 1]
+        input_0_rotated = input_0 * cos_table - input_1 * sin_table
+        input_1_rotated = input_0 * sin_table + input_1 * cos_table
+
+        return torch.stack((input_0_rotated, input_1_rotated), dim=-1).view(input.shape)
+    else:
+        input_0 = input[..., : input.shape[-1] // 2]
+        input_1 = input[..., input.shape[-1] // 2 :]
+        input_0_rotated = input_0 * cos_table - input_1 * sin_table
+        input_1_rotated = input_0 * sin_table + input_1 * cos_table
+
+        return torch.cat((input_0_rotated, input_1_rotated), dim=-1)
+
+
+def _generate_sin_and_cos_tables(
+    seq_len, emb_dim, base=10000, dtype=torch.float32, device="cuda"
+):
+    assert emb_dim % 2 == 0, "The embedding dimension must be even."
+
+    theta = base ** (
+        -2 * (torch.arange(emb_dim // 2, dtype=dtype, device=device) / emb_dim)
+    )
+
+    positions = torch.arange(seq_len, dtype=dtype, device=device).unsqueeze(1)
+    sin_table = torch.sin(positions * theta)
+    cos_table = torch.cos(positions * theta)
+
+    return sin_table, cos_table
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize(
+    "dtype, atol, rtol", ((torch.float32, 0.001, 0), (torch.float16, 0.001, 0.001))
+)
+@pytest.mark.parametrize("inplace", (False, True))
+@pytest.mark.parametrize("interleaved", (False, True))
+@pytest.mark.parametrize("emb_dim", (32, 64))
+@pytest.mark.parametrize("num_heads", (1, 8))
+@pytest.mark.parametrize("seq_len", (1, 128))
+@pytest.mark.parametrize("batch_size", (1, 4))
+def test_cuda(
+    batch_size, seq_len, num_heads, emb_dim, interleaved, inplace, dtype, atol, rtol
+):
+    device = "cuda"
+
+    input = torch.randn(
+        batch_size, seq_len, num_heads, emb_dim, dtype=dtype, device=device
+    )
+    sin_table, cos_table = _generate_sin_and_cos_tables(
+        seq_len, emb_dim, dtype=dtype, device=device
+    )
+
+    ninetoothed_output = ntops.torch.rotary_position_embedding(
+        input.clone() if inplace else input,
+        sin_table,
+        cos_table,
+        interleaved=interleaved,
+        inplace=inplace,
+    )
+    reference_output = _torch_rotary_position_embedding(
+        input, sin_table, cos_table, interleaved=interleaved
+    )
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 494 items

tests/test_abs.py ........                                               [  1%]
tests/test_add.py ........                                               [  3%]
tests/test_addmm.py ..                                                   [  3%]
tests/test_bitwise_and.py ................                               [  6%]
tests/test_bitwise_not.py ................                               [ 10%]
tests/test_bitwise_or.py ................                                [ 13%]
tests/test_bmm.py ..                                                     [ 13%]
tests/test_clamp.py ........                                             [ 15%]
tests/test_cos.py ........                                               [ 17%]
tests/test_div.py ........                                               [ 18%]
tests/test_dropout.py ........                                           [ 20%]
tests/test_eq.py ........                                                [ 21%]
tests/test_exp.py ........                                               [ 23%]
tests/test_ge.py ........                                                [ 25%]
tests/test_gelu.py ........                                              [ 26%]
tests/test_gt.py ........                                                [ 28%]
tests/test_isinf.py ........                                             [ 29%]
tests/test_isnan.py ........                                             [ 31%]
tests/test_le.py ........                                                [ 33%]
tests/test_lt.py ........                                                [ 34%]
tests/test_mm.py ..                                                      [ 35%]
tests/test_mul.py ........                                               [ 36%]
tests/test_ne.py ........                                                [ 38%]
tests/test_neg.py ........                                               [ 40%]
tests/test_pow.py ........                                               [ 41%]
tests/test_relu.py ........                                              [ 43%]
tests/test_rms_norm.py ................................................. [ 53%]
...............                                                          [ 56%]
tests/test_rotary_position_embedding.py ................................ [ 62%]
........................................................................ [ 77%]
........................                                                 [ 82%]
tests/test_rsqrt.py ........                                             [ 83%]
tests/test_scaled_dot_product_attention.py ............................. [ 89%]
...                                                                      [ 90%]
tests/test_sigmoid.py ........                                           [ 91%]
tests/test_silu.py ........                                              [ 93%]
tests/test_sin.py ........                                               [ 95%]
tests/test_softmax.py ........                                           [ 96%]
tests/test_sub.py ........                                               [ 98%]
tests/test_tanh.py ........                                              [100%]

======================= 494 passed in 1358.27s (0:22:38) =======================
```
