### PR TITLE
Update `element_wise.arrangement` to flatten the tensors before tiling

### DIFF
--- a/src/ntops/kernels/element_wise.py
+++ b/src/ntops/kernels/element_wise.py
@@ -9,8 +9,7 @@ def arrangement(*tensors, block_size=None):
 
     assert all(tensor.ndim == ndim or tensor.ndim == 0 for tensor in tensors)
 
-    block_shape = tuple(1 for _ in range(ndim - 1)) + (block_size,)
-
     return tuple(
-        tensor.tile(block_shape) if tensor.ndim != 0 else tensor for tensor in tensors
+        tensor.flatten().tile((block_size,)) if tensor.ndim != 0 else tensor
+        for tensor in tensors
     )


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 494 items

tests/test_abs.py ........                                               [  1%]
tests/test_add.py ........                                               [  3%]
tests/test_addmm.py ..                                                   [  3%]
tests/test_bitwise_and.py ................                               [  6%]
tests/test_bitwise_not.py ................                               [ 10%]
tests/test_bitwise_or.py ................                                [ 13%]
tests/test_bmm.py ..                                                     [ 13%]
tests/test_clamp.py ........                                             [ 15%]
tests/test_cos.py ........                                               [ 17%]
tests/test_div.py ........                                               [ 18%]
tests/test_dropout.py ........                                           [ 20%]
tests/test_eq.py ........                                                [ 21%]
tests/test_exp.py ........                                               [ 23%]
tests/test_ge.py ........                                                [ 25%]
tests/test_gelu.py ........                                              [ 26%]
tests/test_gt.py ........                                                [ 28%]
tests/test_isinf.py ........                                             [ 29%]
tests/test_isnan.py ........                                             [ 31%]
tests/test_le.py ........                                                [ 33%]
tests/test_lt.py ........                                                [ 34%]
tests/test_mm.py ..                                                      [ 35%]
tests/test_mul.py ........                                               [ 36%]
tests/test_ne.py ........                                                [ 38%]
tests/test_neg.py ........                                               [ 40%]
tests/test_pow.py ........                                               [ 41%]
tests/test_relu.py ........                                              [ 43%]
tests/test_rms_norm.py ................................................. [ 53%]
...............                                                          [ 56%]
tests/test_rotary_position_embedding.py ................................ [ 62%]
........................................................................ [ 77%]
........................                                                 [ 82%]
tests/test_rsqrt.py ........                                             [ 83%]
tests/test_scaled_dot_product_attention.py ............................. [ 89%]
...                                                                      [ 90%]
tests/test_sigmoid.py ........                                           [ 91%]
tests/test_silu.py ........                                              [ 93%]
tests/test_sin.py ........                                               [ 95%]
tests/test_softmax.py ........                                           [ 96%]
tests/test_sub.py ........                                               [ 98%]
tests/test_tanh.py ........                                              [100%]

======================= 494 passed in 2046.56s (0:34:06) =======================
```
