### PR TITLE
Add `layer_norm` operator

### DIFF
--- a/src/ntops/kernels/layer_norm.py
+++ b/src/ntops/kernels/layer_norm.py
@@ -1,0 +1,47 @@
+import functools
+import math
+
+import ninetoothed.language as ntl
+from ninetoothed import Tensor
+
+from ntops.kernels.reduction import arrangement
+
+
+def application(input, weight, bias, eps, output, num_normalized_elements):
+    _mean = ntl.zeros(input.dtype.shape, dtype=ntl.float32)
+
+    for i in range(input.shape[0]):
+        _mean += ntl.cast(input[i], ntl.float32)
+
+    mean = ntl.sum(_mean, 0) / num_normalized_elements
+
+    _var = ntl.zeros(input.dtype.shape, dtype=ntl.float32)
+
+    for i in range(input.shape[0]):
+        diff = ntl.cast(input[i], ntl.float32) - mean
+        diff = ntl.where(input[i].offsets(-1) < input.source.shape[-1], diff, 0)
+        _var += diff * diff
+
+    var = ntl.sum(_var, 0) / num_normalized_elements
+
+    std = ntl.sqrt(var + eps)
+
+    for i in range(input.shape[0]):
+        output[i] = (ntl.cast(input[i], ntl.float32) - mean) / std * weight[i] + bias[i]
+
+
+def premake(ndim, normalized_shape, dtype=None, block_size=None):
+    dims = tuple(-(dim + 1) for dim in range(len(normalized_shape)))
+
+    arrangement_ = functools.partial(arrangement, dim=dims, block_size=block_size)
+
+    tensors = (
+        Tensor(ndim, other=0, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(0, dtype=dtype),
+        Tensor(ndim, dtype=dtype),
+        Tensor(0, dtype=dtype, constexpr=True, value=math.prod(normalized_shape)),
+    )
+
+    return arrangement_, application, tensors

--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -23,6 +23,7 @@ import ntops.kernels.gelu
 import ntops.kernels.gt
 import ntops.kernels.isinf
 import ntops.kernels.isnan
+import ntops.kernels.layer_norm
 import ntops.kernels.le
 import ntops.kernels.lt
 import ntops.kernels.mm
@@ -252,6 +253,33 @@ def isnan(input):
     kernel = _cached_make(ntops.kernels.isnan.premake, input.ndim)
 
     kernel(input, output)
+
+    return output
+
+
+def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
+    if isinstance(normalized_shape, int):
+        normalized_shape = (normalized_shape,)
+
+    normalized_shape = tuple(normalized_shape)
+
+    if weight is None:
+        weight = torch.ones_like(input)
+    else:
+        weight = weight.expand_as(input)
+
+    if bias is None:
+        bias = torch.zeros_like(input)
+    else:
+        bias = bias.expand_as(input)
+
+    output = torch.empty_like(input)
+
+    kernel = _cached_make(
+        ntops.kernels.layer_norm.premake, input.ndim, normalized_shape
+    )
+
+    kernel(input, weight, bias, eps, output, math.prod(normalized_shape))
 
     return output
 

--- a/tests/test_layer_norm.py
+++ b/tests/test_layer_norm.py
@@ -1,0 +1,37 @@
+import random
+
+import pytest
+import torch
+
+import ntops.torch
+from tests.skippers import skip_if_cuda_not_available
+from tests.utils import generate_arguments
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize("eps", (1e-8, 1e-5, 1e-3))
+@pytest.mark.parametrize("bias_is_none", (False, True))
+@pytest.mark.parametrize("weight_is_none", (False, True))
+@pytest.mark.parametrize(*generate_arguments())
+def test_cuda(shape, dtype, atol, rtol, weight_is_none, bias_is_none, eps):
+    device = "cuda"
+
+    input = torch.randn(shape, dtype=dtype, device=device)
+    normalized_shape = shape[-random.randint(1, len(shape)) :]
+    if weight_is_none:
+        weight = None
+    else:
+        weight = torch.randn(normalized_shape, dtype=dtype, device=device)
+    if bias_is_none:
+        bias = None
+    else:
+        bias = torch.randn(normalized_shape, dtype=dtype, device=device)
+
+    ninetoothed_output = ntops.torch.layer_norm(
+        input, normalized_shape, weight=weight, bias=bias, eps=eps
+    )
+    reference_output = torch.nn.functional.layer_norm(
+        input, normalized_shape, weight=weight, bias=bias, eps=eps
+    )
+
+    assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 590 items

tests/test_abs.py ........                                               [  1%]
tests/test_add.py ........                                               [  2%]
tests/test_addmm.py ..                                                   [  3%]
tests/test_bitwise_and.py ................                               [  5%]
tests/test_bitwise_not.py ................                               [  8%]
tests/test_bitwise_or.py ................                                [ 11%]
tests/test_bmm.py ..                                                     [ 11%]
tests/test_clamp.py ........                                             [ 12%]
tests/test_cos.py ........                                               [ 14%]
tests/test_div.py ........                                               [ 15%]
tests/test_dropout.py ........                                           [ 16%]
tests/test_eq.py ........                                                [ 18%]
tests/test_exp.py ........                                               [ 19%]
tests/test_ge.py ........                                                [ 21%]
tests/test_gelu.py ........                                              [ 22%]
tests/test_gt.py ........                                                [ 23%]
tests/test_isinf.py ........                                             [ 25%]
tests/test_isnan.py ........                                             [ 26%]
tests/test_layer_norm.py ............................................... [ 34%]
.................................................                        [ 42%]
tests/test_le.py ........                                                [ 44%]
tests/test_lt.py ........                                                [ 45%]
tests/test_mm.py ..                                                      [ 45%]
tests/test_mul.py ........                                               [ 47%]
tests/test_ne.py ........                                                [ 48%]
tests/test_neg.py ........                                               [ 49%]
tests/test_pow.py ........                                               [ 51%]
tests/test_relu.py ........                                              [ 52%]
tests/test_rms_norm.py ................................................. [ 60%]
...............                                                          [ 63%]
tests/test_rotary_position_embedding.py ................................ [ 68%]
........................................................................ [ 81%]
........................                                                 [ 85%]
tests/test_rsqrt.py ........                                             [ 86%]
tests/test_scaled_dot_product_attention.py ............................. [ 91%]
...                                                                      [ 91%]
tests/test_sigmoid.py ........                                           [ 93%]
tests/test_silu.py ........                                              [ 94%]
tests/test_sin.py ........                                               [ 95%]
tests/test_softmax.py ........                                           [ 97%]
tests/test_sub.py ........                                               [ 98%]
tests/test_tanh.py ........                                              [100%]

======================= 590 passed in 430.73s (0:07:10) ========================
```
