### PR TITLE
Add causal variants

### DIFF
--- a/src/ntops/torch.py
+++ b/src/ntops/torch.py
@@ -42,6 +42,7 @@ import ntops.kernels.sin
 import ntops.kernels.softmax
 import ntops.kernels.sub
 import ntops.kernels.tanh
+from ntops.kernels.scaled_dot_product_attention import CausalVariant
 
 
 def abs(input, *, out=None):
@@ -445,6 +446,7 @@ def scaled_dot_product_attention(
     is_causal=False,
     scale=None,
     enable_gqa=False,
+    causal_variant=None,
     present_key=None,
     present_value=None,
     present_key_slot=None,
@@ -490,6 +492,9 @@ def scaled_dot_product_attention(
     if scale is None:
         scale = 1 / math.sqrt(query.shape[-1])
 
+    if causal_variant is None:
+        causal_variant = CausalVariant.UPPER_LEFT
+
     if present_key is not None:
         with_kv_cache = True
     else:
@@ -515,9 +520,20 @@ def scaled_dot_product_attention(
             scale,
             output,
             with_attn_mask,
+            causal_variant,
         )
     else:
-        kernel(query, key, value, attn_mask, is_causal, scale, output, with_attn_mask)
+        kernel(
+            query,
+            key,
+            value,
+            attn_mask,
+            is_causal,
+            scale,
+            output,
+            with_attn_mask,
+            causal_variant,
+        )
 
     return output
 


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ntops
configfile: pyproject.toml
plugins: cov-6.0.0
collected 649 items

tests/test_abs.py ........                                               [  1%]
tests/test_add.py ........                                               [  2%]
tests/test_addmm.py ..                                                   [  2%]
tests/test_bitwise_and.py ................                               [  5%]
tests/test_bitwise_not.py ................                               [  7%]
tests/test_bitwise_or.py ................                                [ 10%]
tests/test_bmm.py ..                                                     [ 10%]
tests/test_clamp.py ........                                             [ 11%]
tests/test_cos.py ........                                               [ 12%]
tests/test_div.py ........                                               [ 14%]
tests/test_dropout.py ........                                           [ 15%]
tests/test_eq.py ........                                                [ 16%]
tests/test_exp.py ........                                               [ 17%]
tests/test_ge.py ........                                                [ 19%]
tests/test_gelu.py ........                                              [ 20%]
tests/test_gt.py ........                                                [ 21%]
tests/test_isinf.py ........                                             [ 22%]
tests/test_isnan.py ........                                             [ 24%]
tests/test_layer_norm.py ............................................... [ 31%]
.................................................                        [ 38%]
tests/test_le.py ........                                                [ 40%]
tests/test_lt.py ........                                                [ 41%]
tests/test_mm.py ..                                                      [ 41%]
tests/test_mul.py ........                                               [ 42%]
tests/test_ne.py ........                                                [ 44%]
tests/test_neg.py ........                                               [ 45%]
tests/test_pow.py ........                                               [ 46%]
tests/test_relu.py ........                                              [ 47%]
tests/test_rms_norm.py ................................................. [ 55%]
...............                                                          [ 57%]
tests/test_rotary_position_embedding.py ................................ [ 62%]
........................................................................ [ 73%]
........................                                                 [ 77%]
tests/test_rsqrt.py ........                                             [ 78%]
tests/test_scaled_dot_product_attention.py ............................. [ 83%]
..............................................................           [ 92%]
tests/test_sigmoid.py ........                                           [ 93%]
tests/test_silu.py ........                                              [ 95%]
tests/test_sin.py ........                                               [ 96%]
tests/test_softmax.py ........                                           [ 97%]
tests/test_sub.py ........                                               [ 98%]
tests/test_tanh.py ........                                              [100%]

======================= 649 passed in 389.43s (0:06:29) ========================
```
