### PR TITLE
Skip invalid test cases for `LOWER_RIGHT` causal variant

### DIFF
--- a/tests/test_scaled_dot_product_attention.py
+++ b/tests/test_scaled_dot_product_attention.py
@@ -59,6 +59,9 @@ def generate_arguments():
             atol = 0.025
             rtol = 0.025
 
+        if causal_variant == CausalVariant.LOWER_RIGHT and seq_len_q > seq_len_kv:
+            continue
+
         arguments.append(
             (
                 batch_size,


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/huang/ntops
configfile: pyproject.toml
plugins: jaxtyping-0.3.2, typeguard-4.4.4, cov-6.2.1, anyio-4.9.0
collected 636 items

tests/test_abs.py ........                                               [  1%]
tests/test_add.py ........                                               [  2%]
tests/test_addmm.py ..                                                   [  2%]
tests/test_bitwise_and.py ................                               [  5%]
tests/test_bitwise_not.py ................                               [  7%]
tests/test_bitwise_or.py ................                                [ 10%]
tests/test_bmm.py ..                                                     [ 10%]
tests/test_clamp.py ........                                             [ 11%]
tests/test_cos.py ........                                               [ 13%]
tests/test_div.py ........                                               [ 14%]
tests/test_dropout.py ...F....                                           [ 15%]
tests/test_eq.py ........                                                [ 16%]
tests/test_exp.py ........                                               [ 18%]
tests/test_ge.py ........                                                [ 19%]
tests/test_gelu.py ........                                              [ 20%]
tests/test_gt.py ........                                                [ 22%]
tests/test_isinf.py ........                                             [ 23%]
tests/test_isnan.py ........                                             [ 24%]
tests/test_layer_norm.py ............................................... [ 31%]
.................................................                        [ 39%]
tests/test_le.py ........                                                [ 40%]
tests/test_lt.py ........                                                [ 42%]
tests/test_mm.py ..                                                      [ 42%]
tests/test_mul.py ........                                               [ 43%]
tests/test_ne.py ........                                                [ 44%]
tests/test_neg.py ........                                               [ 46%]
tests/test_pow.py ........                                               [ 47%]
tests/test_relu.py ........                                              [ 48%]
tests/test_rms_norm.py ........................F........................ [ 56%]
...............                                                          [ 58%]
tests/test_rotary_position_embedding.py ................................ [ 63%]
........................................................................ [ 75%]
........................                                                 [ 78%]
tests/test_rsqrt.py ........                                             [ 80%]
tests/test_scaled_dot_product_attention.py ............................. [ 84%]
.................................................                        [ 92%]
tests/test_sigmoid.py ........                                           [ 93%]
tests/test_silu.py ........                                              [ 94%]
tests/test_sin.py ........                                               [ 96%]
tests/test_softmax.py ........                                           [ 97%]
tests/test_sub.py ........                                               [ 98%]
tests/test_tanh.py ........                                              [100%]

=================================== FAILURES ===================================
______________________ test_cuda[shape3-dtype3-0.01-0.01] ______________________

shape = [23, 11], dtype = torch.float16, atol = 0.01, rtol = 0.01

    @skip_if_cuda_not_available
    @pytest.mark.parametrize(*generate_arguments())
    def test_cuda(shape, dtype, atol, rtol):
        device = "cuda"
    
        input = torch.randn(shape, dtype=dtype, device=device)
        p = random.uniform(0, 1)
    
        # TODO: Add `training` and `inplace` tests later.
        ninetoothed_output = ntops.torch.dropout(input, p=p)
        reference_output = F.dropout(input, p=p)
    
        assert ninetoothed_output.shape == reference_output.shape
    
        ninetoothed_non_zero_ratio = (
            ninetoothed_output.nonzero().numel() / ninetoothed_output.ndim / input.numel()
        )
        reference_non_zero_ratio = (
            reference_output.nonzero().numel() / reference_output.ndim / input.numel()
        )
    
        assert abs(ninetoothed_non_zero_ratio - reference_non_zero_ratio) < 0.1
    
>       assert torch.allclose(
            ninetoothed_output[ninetoothed_output != 0],
            input[ninetoothed_output != 0] / (1 - p),
        )
E       AssertionError: assert False
E        +  where False = <built-in method allclose of type object at 0x7e3bbb77bfa0>(tensor([-2.0059e+00, -6.7236e-01,  9.9170e-01,  4.6997e-01, -1.8750e+00,\n         2.0723e+00,  5.7959e-01, -1.9189e+00... -9.6533e-01,\n         6.7090e-01,  4.3726e-01, -1.0996e+00, -1.1895e+00], device='cuda:0',\n       dtype=torch.float16), (tensor([-1.2695e+00, -4.2529e-01,  6.2744e-01,  2.9736e-01, -1.1865e+00,\n         1.3105e+00,  3.6670e-01, -1.2139e+00... -6.1084e-01,\n         4.2432e-01,  2.7661e-01, -6.9580e-01, -7.5244e-01], device='cuda:0',\n       dtype=torch.float16) / (1 - 0.36734692695968196)))
E        +    where <built-in method allclose of type object at 0x7e3bbb77bfa0> = torch.allclose

tests/test_dropout.py:35: AssertionError
________________ test_cuda[shape3-dtype3-0.01-0.01-False-None] _________________

shape = [172, 4], dtype = torch.float16, atol = 0.01, rtol = 0.01
weight_is_none = False, eps = None

    @skip_if_cuda_not_available
    @pytest.mark.parametrize("eps", (None, 0, 1e-5, 1e-3))
    @pytest.mark.parametrize("weight_is_none", (False, True))
    @pytest.mark.parametrize(*generate_arguments())
    def test_cuda(shape, dtype, atol, rtol, weight_is_none, eps):
        device = "cuda"
    
        input = torch.randn(shape, dtype=dtype, device=device)
        normalized_shape = shape[-random.randint(1, len(shape)) :]
        if weight_is_none:
            weight = None
        else:
            weight = torch.randn(normalized_shape, dtype=dtype, device=device)
    
        ninetoothed_output = ntops.torch.rms_norm(
            input, normalized_shape, weight=weight, eps=eps
        )
        reference_output = torch.nn.functional.rms_norm(
            input, normalized_shape, weight=weight, eps=eps
        )
    
>       assert torch.allclose(ninetoothed_output, reference_output, atol=atol, rtol=rtol)
E       AssertionError: assert False
E        +  where False = <built-in method allclose of type object at 0x7e3bbb77bfa0>(tensor([[-1.5625e+00,  2.2302e-01,  1.8984e+00, -5.7227e-01],\n        [ 1.1641e+00,  1.6455e+00,  2.2148e+00, -1.7583e....8787e-01],\n        [ 1.1514e+00, -5.2188e+00, -2.2839e-01,  2.9126e-01]], device='cuda:0',\n       dtype=torch.float16), tensor([[-1.5625e+00,  2.2302e-01,  1.8984e+00, -5.7275e-01],\n        [ 1.1650e+00,  1.6475e+00,  2.2168e+00, -1.7583e....8799e-01],\n        [ 1.1523e+00, -5.2227e+00, -2.2852e-01,  2.9150e-01]], device='cuda:0',\n       dtype=torch.float16), atol=0.01, rtol=0.01)
E        +    where <built-in method allclose of type object at 0x7e3bbb77bfa0> = torch.allclose

tests/test_rms_norm.py:32: AssertionError
=========================== short test summary info ============================
FAILED tests/test_dropout.py::test_cuda[shape3-dtype3-0.01-0.01] - AssertionE...
FAILED tests/test_rms_norm.py::test_cuda[shape3-dtype3-0.01-0.01-False-None]
================== 2 failed, 634 passed in 409.68s (0:06:49) ===================
```
